### PR TITLE
fix: wire subscription claims into auth interceptor

### DIFF
--- a/backend/internal/auth/firebase.go
+++ b/backend/internal/auth/firebase.go
@@ -50,12 +50,12 @@ func NewFirebaseAuth(ctx context.Context) (*FirebaseAuth, error) {
 	}, nil
 }
 
-// VerifyToken verifies a Firebase ID token and returns user claims
-func (f *FirebaseAuth) VerifyToken(ctx context.Context, idToken string) (*UserClaims, error) {
+// VerifyToken verifies a Firebase ID token and returns user claims plus the raw token claims map.
+func (f *FirebaseAuth) VerifyToken(ctx context.Context, idToken string) (*UserClaims, map[string]interface{}, error) {
 	// Verify the ID token
 	token, err := f.client.VerifyIDToken(ctx, idToken)
 	if err != nil {
-		return nil, fmt.Errorf("failed to verify ID token: %w", err)
+		return nil, nil, fmt.Errorf("failed to verify ID token: %w", err)
 	}
 
 	// Extract user information
@@ -80,7 +80,7 @@ func (f *FirebaseAuth) VerifyToken(ctx context.Context, idToken string) (*UserCl
 		claims.Picture = picture
 	}
 
-	return claims, nil
+	return claims, token.Claims, nil
 }
 
 // ExtractTokenFromHeader extracts the Bearer token from Authorization header

--- a/web/src/app/(app)/personal/analytics/page.tsx
+++ b/web/src/app/(app)/personal/analytics/page.tsx
@@ -25,9 +25,19 @@ import {
   useWaterfallData,
 } from '../../../metrics/hooks/useAnalyticsData';
 import { useExtractionMetrics } from '../../../metrics/hooks/useExtractionMetrics';
+import { UpgradePrompt } from '../../../components/ProFeatureGate';
 import { AlertCircle, FileSearch } from 'lucide-react';
 
+function isSubscriptionError(message: string): boolean {
+  return message.toLowerCase().includes('pro subscription') ||
+    message.toLowerCase().includes('permission_denied');
+}
+
 function ErrorBanner({ message }: { message: string }) {
+  if (isSubscriptionError(message)) {
+    return <UpgradePrompt feature="Advanced Analytics" />;
+  }
+
   return (
     <div className="flex items-center gap-2 p-3 rounded-md bg-destructive/10 text-destructive text-sm">
       <AlertCircle className="h-4 w-4 shrink-0" />


### PR DESCRIPTION
## Summary

- **Backend bug fix**: The auth interceptor was not extracting subscription claims from Firebase tokens into the request context. `RequireProTier()` always got `nil` and rejected Pro users with "this feature requires a Pro subscription". Now `VerifyToken` returns raw claims, and the interceptor calls `GetSubscriptionClaimsFromToken()` + `WithSubscription()` to populate the context.
- **Frontend UX**: When the analytics page receives a subscription-related error, it now shows a styled upgrade prompt (Crown icon, "Upgrade to Pro" button linking to billing) instead of a raw red error banner.

## Root cause

The `VerifyToken` method only returned `*UserClaims` but discarded the raw `token.Claims` map that contains `subscription_tier` and `subscription_status` custom claims. The interceptor had no way to pass subscription info into the context, so `GetSubscription(ctx)` always returned `nil`.

## Test plan
- [x] All backend tests pass (auth, extraction, service)
- [x] All frontend tests pass (92/92)
- [x] `tsc --noEmit` clean
- [x] Pre-commit hooks pass
- [ ] Verify Pro user can access analytics after deploy