### PR TITLE
fix: Firestore date range query ordering and Pro tier store fallback

### DIFF
--- a/backend/internal/auth/interceptor.go
+++ b/backend/internal/auth/interceptor.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"log"
 
 	"connectrpc.com/connect"
 )
@@ -39,6 +40,9 @@ func AuthInterceptor(firebaseAuth *FirebaseAuth) connect.UnaryInterceptorFunc {
 			if rawClaims != nil {
 				subInfo := GetSubscriptionClaimsFromToken(rawClaims)
 				ctx = WithSubscription(ctx, subInfo)
+				log.Printf("[Auth] User %s: tier=%v status=%v (from token claims)", claims.UID, subInfo.Tier, subInfo.Status)
+			} else {
+				log.Printf("[Auth] User %s: no raw claims in token", claims.UID)
 			}
 
 			return next(ctx, req)

--- a/backend/internal/service/analytics_service_test.go
+++ b/backend/internal/service/analytics_service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -38,6 +39,8 @@ func TestAnalyticsGetDailyAggregates(t *testing.T) {
 
 	mockStore := store.NewMockStore(ctrl)
 	service := NewFinanceService(mockStore, nil, nil)
+	// Pro tier fallback may call GetUser for non-Pro contexts
+	mockStore.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("not found")).AnyTimes()
 
 	userID := "user-123"
 
@@ -175,6 +178,8 @@ func TestAnalyticsGetSpendingTrends(t *testing.T) {
 
 	mockStore := store.NewMockStore(ctrl)
 	service := NewFinanceService(mockStore, nil, nil)
+	// Pro tier fallback may call GetUser for non-Pro contexts
+	mockStore.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("not found")).AnyTimes()
 
 	userID := "user-123"
 
@@ -289,6 +294,8 @@ func TestAnalyticsGetCategoryComparison(t *testing.T) {
 
 	mockStore := store.NewMockStore(ctrl)
 	service := NewFinanceService(mockStore, nil, nil)
+	// Pro tier fallback may call GetUser for non-Pro contexts
+	mockStore.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("not found")).AnyTimes()
 
 	userID := "user-123"
 
@@ -425,6 +432,8 @@ func TestAnalyticsDetectAnomalies(t *testing.T) {
 
 	mockStore := store.NewMockStore(ctrl)
 	service := NewFinanceService(mockStore, nil, nil)
+	// Pro tier fallback may call GetUser for non-Pro contexts
+	mockStore.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("not found")).AnyTimes()
 
 	userID := "user-123"
 
@@ -552,6 +561,8 @@ func TestAnalyticsGetCashFlowForecast(t *testing.T) {
 
 	mockStore := store.NewMockStore(ctrl)
 	service := NewFinanceService(mockStore, nil, nil)
+	// Pro tier fallback may call GetUser for non-Pro contexts
+	mockStore.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("not found")).AnyTimes()
 
 	userID := "user-123"
 
@@ -712,6 +723,8 @@ func TestAnalyticsGetWaterfallData(t *testing.T) {
 
 	mockStore := store.NewMockStore(ctrl)
 	service := NewFinanceService(mockStore, nil, nil)
+	// Pro tier fallback may call GetUser for non-Pro contexts
+	mockStore.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("not found")).AnyTimes()
 
 	userID := "user-123"
 


### PR DESCRIPTION
## Summary
- **Firestore query fix**: Queries with date range filters (`Date >= X`, `Date <= Y`) now use `OrderBy("Date")` before `OrderBy(DocumentID)` via a new `applyDateAwarePagination` method, fixing the "order by clause cannot contain more fields after the key" errors in all analytics RPCs
- **Pro tier store fallback**: When Firebase token claims are stale (token issued before Stripe webhook set custom claims), analytics handlers now fall back to checking the Firestore user record for subscription status
- **Auth logging**: Interceptor logs subscription tier extracted from token claims for production diagnostics

## Test plan
- [x] All 6 analytics test suites pass (including `requires_pro_tier` subtests)
- [x] All backend tests pass (`go test ./...`)
- [x] `gofmt` clean
- [ ] Deploy and verify analytics page loads for Pro users
- [ ] Check Cloud Run logs for `[Auth] User ... tier=...` messages