### PR TITLE
fix: analytics charts and extraction Pro gate

### DIFF
--- a/backend/internal/service/ml_feedback_service.go
+++ b/backend/internal/service/ml_feedback_service.go
@@ -377,7 +377,11 @@ func (s *FinanceService) GetExtractionMetrics(ctx context.Context, req *connect.
 		return nil, err
 	}
 
-	if req.Msg.UserId != claims.UID {
+	userID := req.Msg.UserId
+	if userID == "" {
+		userID = claims.UID
+	}
+	if userID != claims.UID {
 		return nil, connect.NewError(connect.CodePermissionDenied, fmt.Errorf("cannot get metrics for another user"))
 	}
 

--- a/backend/scripts/seed-analytics-demo.go
+++ b/backend/scripts/seed-analytics-demo.go
@@ -479,4 +479,3 @@ func randAmount(rng *rand.Rand, min, max float64) float64 {
 	v := min + rng.Float64()*(max-min)
 	return math.Round(v*100) / 100
 }
-

--- a/web/src/app/(app)/personal/analytics/page.tsx
+++ b/web/src/app/(app)/personal/analytics/page.tsx
@@ -29,8 +29,10 @@ import { UpgradePrompt } from '../../../components/ProFeatureGate';
 import { AlertCircle, FileSearch } from 'lucide-react';
 
 function isSubscriptionError(message: string): boolean {
-  return message.toLowerCase().includes('pro subscription') ||
-    message.toLowerCase().includes('permission_denied');
+  const lower = message.toLowerCase();
+  return lower.includes('pro subscription') ||
+    lower.includes('pro tier') ||
+    lower.includes('requires a pro');
 }
 
 function ErrorBanner({ message }: { message: string }) {

--- a/web/src/app/components/charts/AnomalyScatterPlot.tsx
+++ b/web/src/app/components/charts/AnomalyScatterPlot.tsx
@@ -42,9 +42,9 @@ interface TooltipData {
 
 const tooltipStyles: React.CSSProperties = {
   ...defaultStyles,
-  backgroundColor: 'hsl(var(--popover))',
-  color: 'hsl(var(--popover-foreground))',
-  border: '1px solid hsl(var(--border))',
+  backgroundColor: 'var(--popover)',
+  color: 'var(--popover-foreground)',
+  border: '1px solid var(--border)',
   borderRadius: '6px',
   fontSize: '12px',
   padding: '8px 12px',
@@ -63,11 +63,11 @@ function formatDateLabel(date: Date): string {
 function severityColor(severity: 'low' | 'medium' | 'high'): string {
   switch (severity) {
     case 'low':
-      return 'hsl(var(--chart-4))';
+      return 'var(--chart-4)';
     case 'medium':
-      return 'hsl(var(--chart-5))';
+      return 'var(--chart-5)';
     case 'high':
-      return 'hsl(var(--chart-1))';
+      return 'var(--chart-1)';
   }
 }
 
@@ -201,7 +201,7 @@ function ScatterPlot({
           <GridRows
             scale={yScale}
             width={innerWidth}
-            stroke="hsl(var(--border))"
+            stroke="var(--border)"
             strokeOpacity={0.3}
             strokeDasharray="3,3"
             numTicks={5}
@@ -209,7 +209,7 @@ function ScatterPlot({
           <GridColumns
             scale={xScale}
             height={innerHeight}
-            stroke="hsl(var(--border))"
+            stroke="var(--border)"
             strokeOpacity={0.3}
             strokeDasharray="3,3"
             numTicks={6}
@@ -222,7 +222,7 @@ function ScatterPlot({
               cx={xScale(point.date)}
               cy={yScale(point.amount)}
               r={3}
-              fill="hsl(var(--muted-foreground))"
+              fill="var(--muted-foreground)"
               fillOpacity={0.4}
               style={{ cursor: 'pointer' }}
               onMouseMove={(e) => handleNormalHover(e, point)}
@@ -250,7 +250,7 @@ function ScatterPlot({
                   cy={yScale(point.amount)}
                   r={radius}
                   fill={color}
-                  stroke="hsl(var(--background))"
+                  stroke="var(--background)"
                   strokeWidth={1.5}
                   style={{ cursor: 'pointer' }}
                   onMouseMove={(e) => handleAnomalyHover(e, point)}
@@ -266,10 +266,10 @@ function ScatterPlot({
             scale={xScale}
             numTicks={Math.min(6, allDates.length)}
             tickFormat={(d) => formatDateLabel(d as Date)}
-            stroke="hsl(var(--border))"
-            tickStroke="hsl(var(--border))"
+            stroke="var(--border)"
+            tickStroke="var(--border)"
             tickLabelProps={() => ({
-              fill: 'hsl(var(--muted-foreground))',
+              fill: 'var(--muted-foreground)',
               fontSize: 10,
               textAnchor: 'middle' as const,
             })}
@@ -278,10 +278,10 @@ function ScatterPlot({
             scale={yScale}
             numTicks={5}
             tickFormat={(d) => `$${(d as number).toLocaleString()}`}
-            stroke="hsl(var(--border))"
-            tickStroke="hsl(var(--border))"
+            stroke="var(--border)"
+            tickStroke="var(--border)"
             tickLabelProps={() => ({
-              fill: 'hsl(var(--muted-foreground))',
+              fill: 'var(--muted-foreground)',
               fontSize: 10,
               textAnchor: 'end' as const,
               dx: '-0.25em',
@@ -300,19 +300,19 @@ function ScatterPlot({
           display: 'flex',
           gap: 12,
           fontSize: 10,
-          color: 'hsl(var(--muted-foreground))',
+          color: 'var(--muted-foreground)',
         }}
       >
         <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
-          <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'hsl(var(--chart-4))', display: 'inline-block' }} />
+          <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'var(--chart-4)', display: 'inline-block' }} />
           Low
         </span>
         <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
-          <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'hsl(var(--chart-5))', display: 'inline-block' }} />
+          <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'var(--chart-5)', display: 'inline-block' }} />
           Medium
         </span>
         <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
-          <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'hsl(var(--chart-1))', display: 'inline-block' }} />
+          <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'var(--chart-1)', display: 'inline-block' }} />
           High
         </span>
       </div>

--- a/web/src/app/components/charts/CashFlowForecast.tsx
+++ b/web/src/app/components/charts/CashFlowForecast.tsx
@@ -38,9 +38,9 @@ interface TooltipData {
 
 const tooltipStyles: React.CSSProperties = {
   ...defaultStyles,
-  backgroundColor: 'hsl(var(--popover))',
-  color: 'hsl(var(--popover-foreground))',
-  border: '1px solid hsl(var(--border))',
+  backgroundColor: 'var(--popover)',
+  color: 'var(--popover-foreground)',
+  border: '1px solid var(--border)',
   borderRadius: '6px',
   fontSize: '12px',
   padding: '8px 12px',
@@ -90,9 +90,9 @@ function ForecastChart({
 
   const seriesConfigs: SeriesConfig[] = useMemo(
     () => [
-      { label: 'Income', data: incomeForecast, color: 'hsl(var(--chart-2))' },
-      { label: 'Expenses', data: expenseForecast, color: 'hsl(var(--chart-1))' },
-      { label: 'Net', data: netForecast, color: 'hsl(var(--primary))' },
+      { label: 'Income', data: incomeForecast, color: 'var(--chart-2)' },
+      { label: 'Expenses', data: expenseForecast, color: 'var(--chart-1)' },
+      { label: 'Net', data: netForecast, color: 'var(--primary)' },
     ],
     [incomeForecast, expenseForecast, netForecast]
   );
@@ -205,7 +205,7 @@ function ForecastChart({
           <GridRows
             scale={yScale}
             width={innerWidth}
-            stroke="hsl(var(--border))"
+            stroke="var(--border)"
             strokeOpacity={0.3}
             strokeDasharray="3,3"
             numTicks={5}
@@ -269,7 +269,7 @@ function ForecastChart({
               <Line
                 from={{ x: todayX, y: 0 }}
                 to={{ x: todayX, y: innerHeight }}
-                stroke="hsl(var(--muted-foreground))"
+                stroke="var(--muted-foreground)"
                 strokeWidth={1}
                 strokeDasharray="6,4"
               />
@@ -278,7 +278,7 @@ function ForecastChart({
                 y={-4}
                 textAnchor="middle"
                 fontSize={10}
-                fill="hsl(var(--muted-foreground))"
+                fill="var(--muted-foreground)"
               >
                 Today
               </text>
@@ -291,10 +291,10 @@ function ForecastChart({
             scale={xScale}
             numTicks={6}
             tickFormat={(d) => formatDateLabel(d as Date)}
-            stroke="hsl(var(--border))"
-            tickStroke="hsl(var(--border))"
+            stroke="var(--border)"
+            tickStroke="var(--border)"
             tickLabelProps={() => ({
-              fill: 'hsl(var(--muted-foreground))',
+              fill: 'var(--muted-foreground)',
               fontSize: 10,
               textAnchor: 'middle' as const,
             })}
@@ -303,10 +303,10 @@ function ForecastChart({
             scale={yScale}
             numTicks={5}
             tickFormat={(d) => `$${(d as number).toLocaleString()}`}
-            stroke="hsl(var(--border))"
-            tickStroke="hsl(var(--border))"
+            stroke="var(--border)"
+            tickStroke="var(--border)"
             tickLabelProps={() => ({
-              fill: 'hsl(var(--muted-foreground))',
+              fill: 'var(--muted-foreground)',
               fontSize: 10,
               textAnchor: 'end' as const,
               dx: '-0.25em',
@@ -332,7 +332,7 @@ function ForecastChart({
             <Line
               from={{ x: (tooltipLeft ?? 0) - margin.left, y: 0 }}
               to={{ x: (tooltipLeft ?? 0) - margin.left, y: innerHeight }}
-              stroke="hsl(var(--muted-foreground))"
+              stroke="var(--muted-foreground)"
               strokeWidth={1}
               strokeDasharray="3,3"
               pointerEvents="none"
@@ -350,19 +350,19 @@ function ForecastChart({
           display: 'flex',
           gap: 12,
           fontSize: 10,
-          color: 'hsl(var(--muted-foreground))',
+          color: 'var(--muted-foreground)',
         }}
       >
         <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
-          <span style={{ width: 12, height: 2, backgroundColor: 'hsl(var(--chart-2))', display: 'inline-block' }} />
+          <span style={{ width: 12, height: 2, backgroundColor: 'var(--chart-2)', display: 'inline-block' }} />
           Income
         </span>
         <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
-          <span style={{ width: 12, height: 2, backgroundColor: 'hsl(var(--chart-1))', display: 'inline-block' }} />
+          <span style={{ width: 12, height: 2, backgroundColor: 'var(--chart-1)', display: 'inline-block' }} />
           Expenses
         </span>
         <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
-          <span style={{ width: 12, height: 2, backgroundColor: 'hsl(var(--primary))', display: 'inline-block' }} />
+          <span style={{ width: 12, height: 2, backgroundColor: 'var(--primary)', display: 'inline-block' }} />
           Net
         </span>
       </div>
@@ -376,17 +376,17 @@ function ForecastChart({
           <div style={{ fontWeight: 600, marginBottom: 4 }}>
             {formatDateLabel(tooltipData.date)}
             {tooltipData.isForecast && (
-              <span style={{ fontWeight: 400, fontSize: 10, marginLeft: 6, color: 'hsl(var(--muted-foreground))' }}>
+              <span style={{ fontWeight: 400, fontSize: 10, marginLeft: 6, color: 'var(--muted-foreground)' }}>
                 (Forecast)
               </span>
             )}
           </div>
           {tooltipData.income && (
             <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2 }}>
-              <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'hsl(var(--chart-2))', display: 'inline-block' }} />
+              <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'var(--chart-2)', display: 'inline-block' }} />
               Income: {formatAmount(tooltipData.income.predicted)}
               {tooltipData.isForecast && (
-                <span style={{ fontSize: 10, color: 'hsl(var(--muted-foreground))' }}>
+                <span style={{ fontSize: 10, color: 'var(--muted-foreground)' }}>
                   ({formatAmount(tooltipData.income.lower)} - {formatAmount(tooltipData.income.upper)})
                 </span>
               )}
@@ -394,10 +394,10 @@ function ForecastChart({
           )}
           {tooltipData.expense && (
             <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2 }}>
-              <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'hsl(var(--chart-1))', display: 'inline-block' }} />
+              <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'var(--chart-1)', display: 'inline-block' }} />
               Expenses: {formatAmount(tooltipData.expense.predicted)}
               {tooltipData.isForecast && (
-                <span style={{ fontSize: 10, color: 'hsl(var(--muted-foreground))' }}>
+                <span style={{ fontSize: 10, color: 'var(--muted-foreground)' }}>
                   ({formatAmount(tooltipData.expense.lower)} - {formatAmount(tooltipData.expense.upper)})
                 </span>
               )}
@@ -405,10 +405,10 @@ function ForecastChart({
           )}
           {tooltipData.net && (
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-              <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'hsl(var(--primary))', display: 'inline-block' }} />
+              <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'var(--primary)', display: 'inline-block' }} />
               Net: {formatAmount(tooltipData.net.predicted)}
               {tooltipData.isForecast && (
-                <span style={{ fontSize: 10, color: 'hsl(var(--muted-foreground))' }}>
+                <span style={{ fontSize: 10, color: 'var(--muted-foreground)' }}>
                   ({formatAmount(tooltipData.net.lower)} - {formatAmount(tooltipData.net.upper)})
                 </span>
               )}

--- a/web/src/app/components/charts/CategoryRadarChart.tsx
+++ b/web/src/app/components/charts/CategoryRadarChart.tsx
@@ -27,9 +27,9 @@ interface TooltipData {
 
 const tooltipStyles: React.CSSProperties = {
   ...defaultStyles,
-  backgroundColor: 'hsl(var(--popover))',
-  color: 'hsl(var(--popover-foreground))',
-  border: '1px solid hsl(var(--border))',
+  backgroundColor: 'var(--popover)',
+  color: 'var(--popover-foreground)',
+  border: '1px solid var(--border)',
   borderRadius: '6px',
   fontSize: '12px',
   padding: '8px 12px',
@@ -161,7 +161,7 @@ function RadarChart({
               cy={cy}
               r={maxRadius * level}
               fill="none"
-              stroke="hsl(var(--border))"
+              stroke="var(--border)"
               strokeOpacity={0.4}
               strokeDasharray={level < 1 ? '2,3' : undefined}
             />
@@ -178,7 +178,7 @@ function RadarChart({
                 y1={cy}
                 x2={end.x}
                 y2={end.y}
-                stroke="hsl(var(--border))"
+                stroke="var(--border)"
                 strokeOpacity={0.4}
               />
             );
@@ -189,7 +189,7 @@ function RadarChart({
             <path
               d={budgetPath}
               fill="none"
-              stroke="hsl(var(--chart-4))"
+              stroke="var(--chart-4)"
               strokeWidth={1.5}
               strokeDasharray="5,3"
               opacity={0.7}
@@ -199,9 +199,9 @@ function RadarChart({
           {/* Previous period polygon (outline muted) */}
           <path
             d={previousPath}
-            fill="hsl(var(--muted))"
+            fill="var(--muted)"
             fillOpacity={0.15}
-            stroke="hsl(var(--muted-foreground))"
+            stroke="var(--muted-foreground)"
             strokeWidth={1}
             strokeDasharray="3,3"
           />
@@ -209,9 +209,9 @@ function RadarChart({
           {/* Current period polygon (filled primary) */}
           <path
             d={currentPath}
-            fill="hsl(var(--primary))"
+            fill="var(--primary)"
             fillOpacity={0.25}
-            stroke="hsl(var(--primary))"
+            stroke="var(--primary)"
             strokeWidth={2}
           />
 
@@ -227,8 +227,8 @@ function RadarChart({
                 cx={pos.x}
                 cy={pos.y}
                 r={3.5}
-                fill="hsl(var(--primary))"
-                stroke="hsl(var(--background))"
+                fill="var(--primary)"
+                stroke="var(--background)"
                 strokeWidth={1.5}
               />
             );
@@ -250,7 +250,7 @@ function RadarChart({
                 textAnchor={textAnchor}
                 dominantBaseline="middle"
                 fontSize={11}
-                fill="hsl(var(--foreground))"
+                fill="var(--foreground)"
                 style={{ fontWeight: 500 }}
               >
                 {d.category}
@@ -288,16 +288,16 @@ function RadarChart({
         >
           <div style={{ fontWeight: 600, marginBottom: 4 }}>{tooltipData.category}</div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2 }}>
-            <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'hsl(var(--primary))', display: 'inline-block' }} />
+            <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'var(--primary)', display: 'inline-block' }} />
             Current: {formatAmount(tooltipData.currentValue)}
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2 }}>
-            <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'hsl(var(--muted-foreground))', display: 'inline-block' }} />
+            <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'var(--muted-foreground)', display: 'inline-block' }} />
             Previous: {formatAmount(tooltipData.previousValue)}
           </div>
           {tooltipData.budgetValue != null && (
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-              <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'hsl(var(--chart-4))', display: 'inline-block' }} />
+              <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'var(--chart-4)', display: 'inline-block' }} />
               Budget: {formatAmount(tooltipData.budgetValue)}
             </div>
           )}

--- a/web/src/app/components/charts/SpendingHeatmap.tsx
+++ b/web/src/app/components/charts/SpendingHeatmap.tsx
@@ -41,9 +41,9 @@ interface TooltipData {
 
 const tooltipStyles: React.CSSProperties = {
   ...defaultStyles,
-  backgroundColor: 'hsl(var(--popover))',
-  color: 'hsl(var(--popover-foreground))',
-  border: '1px solid hsl(var(--border))',
+  backgroundColor: 'var(--popover)',
+  color: 'var(--popover-foreground)',
+  border: '1px solid var(--border)',
   borderRadius: '6px',
   fontSize: '12px',
   padding: '8px 12px',
@@ -165,7 +165,7 @@ function HeatmapChart({
     () =>
       scaleLinear<string>({
         domain: [0, data.maxValue * 0.5, data.maxValue],
-        range: ['hsl(var(--muted))', 'hsl(var(--primary))', 'hsl(var(--chart-1))'],
+        range: ['var(--muted)', 'var(--primary)', 'var(--chart-1)'],
       }),
     [data.maxValue]
   );
@@ -225,7 +225,7 @@ function HeatmapChart({
               x={m.x}
               y={0}
               fontSize={10}
-              fill="hsl(var(--muted-foreground))"
+              fill="var(--muted-foreground)"
               textAnchor="start"
             >
               {m.label}
@@ -241,7 +241,7 @@ function HeatmapChart({
               x={margin.left - 6}
               y={i * (adjustedCellSize + gap) + adjustedCellSize / 2}
               fontSize={9}
-              fill="hsl(var(--muted-foreground))"
+              fill="var(--muted-foreground)"
               textAnchor="end"
               dominantBaseline="middle"
             >

--- a/web/src/app/components/charts/SpendingTrendChart.tsx
+++ b/web/src/app/components/charts/SpendingTrendChart.tsx
@@ -42,9 +42,9 @@ interface TooltipData {
 
 const tooltipStyles: React.CSSProperties = {
   ...defaultStyles,
-  backgroundColor: 'hsl(var(--popover))',
-  color: 'hsl(var(--popover-foreground))',
-  border: '1px solid hsl(var(--border))',
+  backgroundColor: 'var(--popover)',
+  color: 'var(--popover-foreground)',
+  border: '1px solid var(--border)',
   borderRadius: '6px',
   fontSize: '12px',
   padding: '8px 12px',
@@ -208,7 +208,7 @@ function TrendChart({
           <GridRows
             scale={yScale}
             width={innerWidth}
-            stroke="hsl(var(--border))"
+            stroke="var(--border)"
             strokeOpacity={0.5}
             strokeDasharray="3,3"
             numTicks={5}
@@ -223,7 +223,7 @@ function TrendChart({
                 y={(d) => yScale(d.value) ?? 0}
                 yScale={yScale}
                 curve={curveMonotoneX}
-                fill="hsl(var(--chart-2))"
+                fill="var(--chart-2)"
                 fillOpacity={0.2}
               />
               <LinePath
@@ -231,7 +231,7 @@ function TrendChart({
                 x={(d) => xScale(d.date) ?? 0}
                 y={(d) => yScale(d.value) ?? 0}
                 curve={curveMonotoneX}
-                stroke="hsl(var(--chart-2))"
+                stroke="var(--chart-2)"
                 strokeWidth={2}
               />
             </>
@@ -244,7 +244,7 @@ function TrendChart({
             y={(d) => yScale(d.value) ?? 0}
             yScale={yScale}
             curve={curveMonotoneX}
-            fill="hsl(var(--chart-1))"
+            fill="var(--chart-1)"
             fillOpacity={0.2}
           />
           <LinePath
@@ -252,7 +252,7 @@ function TrendChart({
             x={(d) => xScale(d.date) ?? 0}
             y={(d) => yScale(d.value) ?? 0}
             curve={curveMonotoneX}
-            stroke="hsl(var(--chart-1))"
+            stroke="var(--chart-1)"
             strokeWidth={2}
           />
 
@@ -262,7 +262,7 @@ function TrendChart({
               data={trendLine}
               x={(d) => xScale(d.date) ?? 0}
               y={(d) => yScale(d.value) ?? 0}
-              stroke="hsl(var(--primary))"
+              stroke="var(--primary)"
               strokeWidth={1.5}
               strokeDasharray="6,4"
             />
@@ -274,10 +274,10 @@ function TrendChart({
             scale={xScale}
             numTicks={Math.min(6, expenseSeries.length)}
             tickFormat={(d) => formatDateLabel(d as Date)}
-            stroke="hsl(var(--border))"
-            tickStroke="hsl(var(--border))"
+            stroke="var(--border)"
+            tickStroke="var(--border)"
             tickLabelProps={() => ({
-              fill: 'hsl(var(--muted-foreground))',
+              fill: 'var(--muted-foreground)',
               fontSize: 10,
               textAnchor: 'middle' as const,
             })}
@@ -286,10 +286,10 @@ function TrendChart({
             scale={yScale}
             numTicks={5}
             tickFormat={(d) => `$${(d as number).toLocaleString()}`}
-            stroke="hsl(var(--border))"
-            tickStroke="hsl(var(--border))"
+            stroke="var(--border)"
+            tickStroke="var(--border)"
             tickLabelProps={() => ({
-              fill: 'hsl(var(--muted-foreground))',
+              fill: 'var(--muted-foreground)',
               fontSize: 10,
               textAnchor: 'end' as const,
               dx: '-0.25em',
@@ -316,7 +316,7 @@ function TrendChart({
               <Line
                 from={{ x: (tooltipLeft ?? 0) - margin.left, y: 0 }}
                 to={{ x: (tooltipLeft ?? 0) - margin.left, y: innerHeight }}
-                stroke="hsl(var(--muted-foreground))"
+                stroke="var(--muted-foreground)"
                 strokeWidth={1}
                 strokeDasharray="3,3"
                 pointerEvents="none"
@@ -325,8 +325,8 @@ function TrendChart({
                 cx={(tooltipLeft ?? 0) - margin.left}
                 cy={(tooltipTop ?? 0) - margin.top}
                 r={4}
-                fill="hsl(var(--chart-1))"
-                stroke="hsl(var(--background))"
+                fill="var(--chart-1)"
+                stroke="var(--background)"
                 strokeWidth={2}
                 pointerEvents="none"
               />
@@ -343,7 +343,7 @@ function TrendChart({
             top: margin.top + 4,
             right: margin.right + 4,
             fontSize: 10,
-            color: 'hsl(var(--muted-foreground))',
+            color: 'var(--muted-foreground)',
           }}
         >
           R² = {trendRSquared.toFixed(3)}
@@ -360,12 +360,12 @@ function TrendChart({
             {formatDateLabel(tooltipData.date)}
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2 }}>
-            <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'hsl(var(--chart-1))', display: 'inline-block' }} />
+            <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'var(--chart-1)', display: 'inline-block' }} />
             Expenses: {formatAmount(tooltipData.expense)}
           </div>
           {tooltipData.income != null && (
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-              <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'hsl(var(--chart-2))', display: 'inline-block' }} />
+              <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: 'var(--chart-2)', display: 'inline-block' }} />
               Income: {formatAmount(tooltipData.income)}
             </div>
           )}

--- a/web/src/app/components/charts/WaterfallChart.tsx
+++ b/web/src/app/components/charts/WaterfallChart.tsx
@@ -32,9 +32,9 @@ interface TooltipData {
 
 const tooltipStyles: React.CSSProperties = {
   ...defaultStyles,
-  backgroundColor: 'hsl(var(--popover))',
-  color: 'hsl(var(--popover-foreground))',
-  border: '1px solid hsl(var(--border))',
+  backgroundColor: 'var(--popover)',
+  color: 'var(--popover-foreground)',
+  border: '1px solid var(--border)',
   borderRadius: '6px',
   fontSize: '12px',
   padding: '8px 12px',
@@ -61,17 +61,17 @@ function getBarColor(bar: WaterfallBar): string {
   if (bar.color) return bar.color;
   switch (bar.type) {
     case 'income':
-      return 'hsl(var(--chart-2))';
+      return 'var(--chart-2)';
     case 'expense':
-      return 'hsl(var(--chart-1))';
+      return 'var(--chart-1)';
     case 'tax':
-      return 'hsl(var(--chart-4))';
+      return 'var(--chart-4)';
     case 'savings':
-      return 'hsl(var(--primary))';
+      return 'var(--primary)';
     case 'subtotal':
-      return 'hsl(var(--muted-foreground))';
+      return 'var(--muted-foreground)';
     default:
-      return 'hsl(var(--muted-foreground))';
+      return 'var(--muted-foreground)';
   }
 }
 
@@ -183,7 +183,7 @@ function WaterfallInner({
           <GridRows
             scale={yScale}
             width={innerWidth}
-            stroke="hsl(var(--border))"
+            stroke="var(--border)"
             strokeOpacity={0.3}
             strokeDasharray="3,3"
             numTicks={5}
@@ -193,7 +193,7 @@ function WaterfallInner({
           <Line
             from={{ x: 0, y: yScale(0) }}
             to={{ x: innerWidth, y: yScale(0) }}
-            stroke="hsl(var(--border))"
+            stroke="var(--border)"
             strokeWidth={1}
           />
 
@@ -212,7 +212,7 @@ function WaterfallInner({
                 key={`connector-${i}`}
                 from={{ x: currentX, y: connectY }}
                 to={{ x: nextX, y: connectY }}
-                stroke="hsl(var(--muted-foreground))"
+                stroke="var(--muted-foreground)"
                 strokeWidth={1}
                 strokeDasharray="2,2"
                 strokeOpacity={0.5}
@@ -262,7 +262,7 @@ function WaterfallInner({
                     textAnchor="middle"
                     verticalAnchor="middle"
                     fontSize={10}
-                    fill="hsl(var(--foreground))"
+                    fill="var(--foreground)"
                     fontWeight={500}
                   >
                     {formatCompactAmount(cb.bar.amount)}
@@ -276,10 +276,10 @@ function WaterfallInner({
           <AxisBottom
             top={innerHeight}
             scale={xScale}
-            stroke="hsl(var(--border))"
-            tickStroke="hsl(var(--border))"
+            stroke="var(--border)"
+            tickStroke="var(--border)"
             tickLabelProps={() => ({
-              fill: 'hsl(var(--muted-foreground))',
+              fill: 'var(--muted-foreground)',
               fontSize: 10,
               textAnchor: 'middle' as const,
               dy: '0.25em',
@@ -290,7 +290,7 @@ function WaterfallInner({
                 y={y}
                 dy="0.75em"
                 fontSize={10}
-                fill="hsl(var(--muted-foreground))"
+                fill="var(--muted-foreground)"
                 textAnchor="middle"
                 style={{
                   maxWidth: xScale.bandwidth?.() ?? 60,
@@ -305,10 +305,10 @@ function WaterfallInner({
             scale={yScale}
             numTicks={5}
             tickFormat={(d) => `$${(d as number).toLocaleString()}`}
-            stroke="hsl(var(--border))"
-            tickStroke="hsl(var(--border))"
+            stroke="var(--border)"
+            tickStroke="var(--border)"
             tickLabelProps={() => ({
-              fill: 'hsl(var(--muted-foreground))',
+              fill: 'var(--muted-foreground)',
               fontSize: 10,
               textAnchor: 'end' as const,
               dx: '-0.25em',
@@ -327,7 +327,7 @@ function WaterfallInner({
           <div style={{ fontWeight: 600, marginBottom: 4 }}>{tooltipData.label}</div>
           <div>Amount: {formatAmount(tooltipData.amount)}</div>
           <div>Running Total: {formatAmount(tooltipData.runningTotal)}</div>
-          <div style={{ marginTop: 4, fontSize: 10, color: 'hsl(var(--muted-foreground))' }}>
+          <div style={{ marginTop: 4, fontSize: 10, color: 'var(--muted-foreground)' }}>
             Type: {tooltipData.type}
           </div>
         </TooltipWithBounds>

--- a/web/src/app/metrics/hooks/useAnalyticsData.ts
+++ b/web/src/app/metrics/hooks/useAnalyticsData.ts
@@ -164,16 +164,16 @@ function waterfallEntryTypeToString(
 function waterfallEntryColor(t: WaterfallEntryType): string {
   switch (t) {
     case WaterfallEntryType.INCOME:
-      return 'hsl(var(--chart-2))';
+      return 'var(--chart-2)';
     case WaterfallEntryType.EXPENSE:
-      return 'hsl(var(--chart-1))';
+      return 'var(--chart-1)';
     case WaterfallEntryType.TAX:
-      return 'hsl(var(--chart-4))';
+      return 'var(--chart-4)';
     case WaterfallEntryType.SAVINGS:
-      return 'hsl(var(--chart-3))';
+      return 'var(--chart-3)';
     case WaterfallEntryType.SUBTOTAL:
     default:
-      return 'hsl(var(--muted))';
+      return 'var(--muted)';
   }
 }
 


### PR DESCRIPTION
## Summary
- Fix analytics charts showing near-zero values after Phase B money migration by using `AmountCents` (via new `effectiveDollars()` helper) instead of deprecated `Amount` field across all 5 analytics handlers
- Fix Extraction tab falsely showing Pro gate by defaulting empty `userId` to authenticated user in `GetExtractionMetrics`
- Tighten `isSubscriptionError()` to avoid false positives on generic permission errors
- Fix gofmt on seed-analytics-demo.go

## Test plan
- [x] Backend builds and all service tests pass
- [x] gofmt clean
- [ ] Verify analytics charts (Heatmap, Trends, Categories, Anomalies, Forecast, Flow) render with correct values
- [ ] Verify Extraction tab loads metrics instead of showing Pro gate