### PR TITLE
fix: restore Sankey diagram link paths

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "frontend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 1234,
+      "cwd": "web"
+    },
+    {
+      "name": "backend",
+      "runtimeExecutable": "go",
+      "runtimeArgs": ["run", "cmd/server/main.go"],
+      "port": 8111,
+      "cwd": "backend",
+      "env": {
+        "PORT": "8111",
+        "USE_MEMORY_STORE": "true",
+        "GOOGLE_CLOUD_PROJECT": "pfinance-app-1748773335"
+      }
+    }
+  ]
+}

--- a/web/src/app/components/ExpenseSankey.tsx
+++ b/web/src/app/components/ExpenseSankey.tsx
@@ -146,18 +146,18 @@ export default function ExpenseSankey({ displayPeriod }: ExpenseSankeyProps) {
               nodePadding={10}
               extent={[[1, 1], [width - 1, height - 6]]}
             >
-              {({ graph }) => (
+              {({ graph, createPath }) => (
                 <svg width={width} height={height}>
                   <defs>
                    {/* Gradients could go here */}
                   </defs>
-                  
+
                   {/* Links */}
                   <g>
                     {graph.links.map((link: any, i: number) => (
                       <path
                         key={`link-${i}`}
-                        d={link.path || ''}
+                        d={createPath(link) || ''}
                         stroke={link.source.name === 'Total Income' || link.source.name === 'Total Funding (Deficit)' 
                           ? colorScale(link.target.name ?? '') 
                           : colorScale(link.target.name ?? '')}


### PR DESCRIPTION
## Summary
- Fixed broken Sankey diagram in the reports view where node connections (link paths) were not rendering
- The `ExpenseSankey` component was missing `createPath` from the `@visx/sankey` render prop, causing `link.path` (undefined) to be used instead of the proper `createPath(link)` path generator

## Test plan
- [x] TypeScript type-check passes
- [x] All backend unit tests pass
- [x] Pre-commit hooks pass (lint + tests)
- [ ] Visually verify Sankey links render between Income → Expenses/Savings → Categories in the reports view