### PR TITLE
ci: use ko for Go container builds and remove E2E from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,96 +117,6 @@ jobs:
         run: cd backend && go build -o server cmd/server/main.go
 
   # ===========================================
-  # E2E Tests (~2 min) - Runs in parallel!
-  # ===========================================
-  e2e:
-    needs: changes
-    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-          cache-dependency-path: web/package-lock.json
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-          cache-dependency-path: backend/go.sum
-
-      - uses: bufbuild/buf-setup-action@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      # Cache Playwright browsers
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}
-
-      - name: Install dependencies & generate code
-        run: |
-          # Install mockgen and generate backend code
-          go install go.uber.org/mock/mockgen@latest
-          (cd proto && buf generate)
-          (cd backend && go generate ./internal/store) &
-
-          # Install frontend deps in parallel
-          (cd web && rm -rf node_modules package-lock.json && npm install --legacy-peer-deps) &
-
-          wait
-
-      - name: Install Playwright (Chromium only)
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        working-directory: web
-        run: npm exec playwright -- install chromium --with-deps
-
-      - name: Install Playwright deps (if cached)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        working-directory: web
-        run: npm exec playwright -- install-deps chromium
-
-      - name: Build & start services
-        run: |
-          # Build backend
-          (cd backend && go build -o server cmd/server/main.go)
-
-          # Start backend in background
-          (cd backend && PORT=8111 USE_MEMORY_STORE=true ./server) &
-
-          # Start frontend in dev mode (faster than build)
-          (cd web && npm run dev) &
-
-          # Wait for services to be ready
-          echo "Waiting for backend..."
-          timeout 60 bash -c 'until curl -s http://localhost:8111/health > /dev/null 2>&1; do sleep 1; done' || exit 1
-          echo "Backend ready!"
-
-          echo "Waiting for frontend..."
-          timeout 90 bash -c 'until curl -s http://localhost:1234 > /dev/null 2>&1; do sleep 1; done' || exit 1
-          echo "Frontend ready!"
-
-      - name: Run E2E tests
-        working-directory: web
-        run: npm run test:e2e -- --project=chromium --reporter=list
-        env:
-          NEXT_PUBLIC_API_URL: http://localhost:8111
-
-      - name: Upload test artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: web/test-results/
-          retention-days: 7
-
-  # ===========================================
   # Proto Validation (~30s)
   # ===========================================
   proto:
@@ -264,7 +174,7 @@ jobs:
   # CI Status Check (for branch protection)
   # ===========================================
   ci-status:
-    needs: [frontend, backend, e2e, proto, firebase, ml-benchmarks]
+    needs: [frontend, backend, proto, firebase, ml-benchmarks]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -273,7 +183,6 @@ jobs:
           # Check if any required job failed
           if [[ "${{ needs.frontend.result }}" == "failure" ]] || \
              [[ "${{ needs.backend.result }}" == "failure" ]] || \
-             [[ "${{ needs.e2e.result }}" == "failure" ]] || \
              [[ "${{ needs.proto.result }}" == "failure" ]] || \
              [[ "${{ needs.firebase.result }}" == "failure" ]] || \
              [[ "${{ needs.ml-benchmarks.result }}" == "failure" ]]; then

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -82,6 +82,9 @@ jobs:
           cache: true
           cache-dependency-path: backend/go.sum
 
+      - uses: ko-build/setup-ko@v0.9
+        if: needs.changes.outputs.backend == 'true'
+
       - uses: bufbuild/buf-setup-action@v1
         if: needs.changes.outputs.backend == 'true'
         with:
@@ -89,22 +92,23 @@ jobs:
 
       - name: Build & Deploy
         if: needs.changes.outputs.backend == 'true'
+        env:
+          KO_DOCKER_REPO: ${{ env.IMAGE_NAME }}
         run: |
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
           go install connectrpc.com/connect/cmd/protoc-gen-connect-go@latest
           go install go.uber.org/mock/mockgen@latest
           export PATH=$PATH:$(go env GOPATH)/bin
           cd proto && buf generate --template buf.gen.go.yaml
-          cd ../backend
+          cd ..
 
           TAG="pr-${{ github.event.pull_request.number }}"
           SERVICE="pfinance-backend-preview-$TAG"
 
-          docker build -t ${{ env.IMAGE_NAME }}:$TAG .
-          docker push ${{ env.IMAGE_NAME }}:$TAG
+          IMAGE=$(ko build ./backend/cmd/server --bare --tags=$TAG)
 
           gcloud run deploy $SERVICE \
-            --image ${{ env.IMAGE_NAME }}:$TAG \
+            --image $IMAGE \
             --region ${{ env.REGION }} \
             --platform managed \
             --allow-unauthenticated \
@@ -237,112 +241,6 @@ jobs:
               comment.user.type === 'Bot' &&
               comment.body.includes('Preview Deployment Ready')
             );
-
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: body
-              });
-            }
-
-  # ===========================================
-  # E2E Tests against Preview
-  # ===========================================
-  e2e-preview:
-    needs: [frontend]
-    if: needs.frontend.result == 'success'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: web/package-lock.json
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}
-
-      - name: Install dependencies
-        run: cd web && npm install --legacy-peer-deps
-
-      - name: Install Playwright (Chromium only)
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        working-directory: web
-        run: npm exec playwright -- install chromium --with-deps
-
-      - name: Install Playwright deps (if cached)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        working-directory: web
-        run: npm exec playwright -- install-deps chromium
-
-      - name: Wait for preview to be ready
-        run: |
-          URL="https://pr-${{ github.event.pull_request.number }}.${{ env.PREVIEW_DOMAIN }}"
-          echo "Waiting for $URL to be ready..."
-          timeout 120 bash -c "until curl -sf --max-time 5 \"$URL\" > /dev/null 2>&1; do echo 'Waiting...'; sleep 5; done" || {
-            echo "::warning::Preview at $URL not ready after 120s, skipping E2E"
-            echo "SKIP_E2E=true" >> $GITHUB_ENV
-          }
-          echo "Preview ready!"
-
-      - name: Run E2E tests against preview
-        if: env.SKIP_E2E != 'true'
-        working-directory: web
-        run: npm run test:e2e:preview -- --reporter=list
-        env:
-          PREVIEW_URL: https://pr-${{ github.event.pull_request.number }}.${{ env.PREVIEW_DOMAIN }}
-
-      - name: Upload test artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-preview-report
-          path: web/test-results/
-          retention-days: 7
-
-      - name: Comment PR with test results
-        if: always()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const success = '${{ job.status }}' === 'success';
-            const emoji = success ? '✅' : '❌';
-            const status = success ? 'passed' : 'failed';
-
-            // Find existing E2E comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const botComment = comments.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('E2E Preview Tests')
-            );
-
-            const body = `### ${emoji} E2E Preview Tests ${status}
-
-            Tested against: https://pr-${{ github.event.pull_request.number }}.${{ env.PREVIEW_DOMAIN }}
-
-            ${success ? 'All smoke tests passed!' : 'Some tests failed. Check the workflow logs for details.'}`;
 
             if (botComment) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   # ===========================================
-  # 1. Build Backend (Docker)
+  # 1. Build Backend (ko)
   # ===========================================
   build-backend:
     runs-on: ubuntu-latest
@@ -28,7 +28,7 @@ jobs:
       contents: read
       id-token: write
     outputs:
-      image: ${{ env.IMAGE_NAME }}:${{ github.sha }}
+      image: ${{ steps.build.outputs.image }}
     steps:
       - uses: actions/checkout@v4
 
@@ -48,19 +48,24 @@ jobs:
           go-version: '1.25'
           cache-dependency-path: backend/go.sum
 
+      - uses: ko-build/setup-ko@v0.9
+
       - uses: bufbuild/buf-setup-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & Push
+        id: build
+        env:
+          KO_DOCKER_REPO: ${{ env.IMAGE_NAME }}
         run: |
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
           go install connectrpc.com/connect/cmd/protoc-gen-connect-go@latest
           export PATH=$PATH:$(go env GOPATH)/bin
           cd proto && buf generate --template buf.gen.go.yaml
-          cd ../backend
-          docker build -t ${{ env.IMAGE_NAME }}:${{ github.sha }} .
-          docker push ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          cd ..
+          IMAGE=$(ko build ./backend/cmd/server --bare --tags=${{ github.sha }})
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
 
   # ===========================================
   # 2. Deploy Backend (Cloud Run)

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,1 @@
+defaultBaseImage: cgr.dev/chainguard/static:latest


### PR DESCRIPTION
## Summary
- Replace Docker multi-stage builds with **ko** for Go container images across all deploy workflows (preview + production), using `cgr.dev/chainguard/static` as the base image for smaller, more secure containers
- Remove E2E test jobs from CI (`ci.yml`) and preview deploys (`preview-deploy.yml`) — these should be run locally via `make test-e2e` instead
- Add `.ko.yaml` config and `make ko-build` target for local container builds

## Test plan
- [ ] Verify CI workflow passes without E2E jobs
- [ ] Verify preview deploy builds backend image with ko successfully
- [ ] Verify production deploy builds and pushes image with ko
- [ ] Run `make test-e2e` locally to confirm E2E tests still work outside CI