### PR TITLE
Unified search: Cmd+K for goals/budgets, ExpenseList search, chat search tools

### DIFF
--- a/web/src/app/components/ExpenseList.tsx
+++ b/web/src/app/components/ExpenseList.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useFinance } from '../context/FinanceContext';
+import { useAuth } from '../context/AuthWithAdminContext';
+import { financeClient } from '@/lib/financeService';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -39,11 +41,15 @@ import { Input } from '@/components/ui/input';
 import { useForm } from 'react-hook-form';
 import { Expense, ExpenseCategory, ExpenseFrequency } from '../types';
 import { useRouter } from 'next/navigation';
-import { Pencil, Trash2, Share2, X, CalendarDays } from 'lucide-react';
+import { Pencil, Trash2, Share2, X, CalendarDays, Search, ChevronLeft, ChevronRight, Loader2 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { getCategoryColor, getFrequencyColor, getInstrumentBadgeStyle } from '../constants/theme';
 import ContributeExpenseModal from './ContributeExpenseModal';
 import { useMultiUserFinance } from '../context/MultiUserFinanceContext';
+import { SearchResult, TransactionType } from '@/gen/pfinance/v1/types_pb';
+import { timestampDate } from '@bufbuild/protobuf/wkt';
+
+const PAGE_SIZE = 25;
 
 type EditFormData = {
   description: string;
@@ -60,8 +66,31 @@ interface ExpenseListProps {
   onClearFilter?: () => void;
 }
 
+// Convert a SearchResult to a display-friendly shape matching Expense
+function searchResultToDisplay(result: SearchResult): {
+  id: string;
+  description: string;
+  category: string;
+  amount: number;
+  date: Date;
+  groupId: string;
+} {
+  const amountCents = Number(result.amountCents);
+  const amount = amountCents !== 0 ? amountCents / 100 : result.amount;
+  const date = result.date ? timestampDate(result.date) : new Date();
+  return {
+    id: result.id,
+    description: result.description,
+    category: result.category,
+    amount,
+    date,
+    groupId: result.groupId,
+  };
+}
+
 export default function ExpenseList({ limit, filterDate, onClearFilter }: ExpenseListProps = {}) {
   const { expenses, deleteExpense, deleteExpenses, updateExpense } = useFinance();
+  const { user } = useAuth();
   const { groups } = useMultiUserFinance();
   const router = useRouter();
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
@@ -73,6 +102,17 @@ export default function ExpenseList({ limit, filterDate, onClearFilter }: Expens
   const [selectedExpenseIds, setSelectedExpenseIds] = useState<Set<string>>(new Set());
   const [lastSelectedIndex, setLastSelectedIndex] = useState<number | null>(null);
   const [isShiftPressed, setIsShiftPressed] = useState(false);
+
+  // Pagination state
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // Search state
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const [searchTotalCount, setSearchTotalCount] = useState(0);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Check if user has groups to share with
   const canShare = groups.length > 0;
@@ -89,6 +129,28 @@ export default function ExpenseList({ limit, filterDate, onClearFilter }: Expens
     });
   }, [expenses, filterDate]);
 
+  // Pagination computed values
+  const totalPages = Math.max(1, Math.ceil(filteredExpenses.length / PAGE_SIZE));
+  const paginatedExpenses = useMemo(() => {
+    if (limit) return filteredExpenses.slice(0, limit);
+    const start = (currentPage - 1) * PAGE_SIZE;
+    return filteredExpenses.slice(start, start + PAGE_SIZE);
+  }, [filteredExpenses, currentPage, limit]);
+
+  // Reset page when filters or data change
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [filterDate, expenses]);
+
+  // Search display items
+  const searchDisplayItems = useMemo(() => {
+    return searchResults.map(searchResultToDisplay);
+  }, [searchResults]);
+
+  // Determine which items to display
+  const displayItems = isSearching ? searchDisplayItems : paginatedExpenses;
+  const displayExpenses = filteredExpenses;
+
   const form = useForm<EditFormData>({
     defaultValues: {
       description: '',
@@ -97,6 +159,55 @@ export default function ExpenseList({ limit, filterDate, onClearFilter }: Expens
       frequency: 'monthly',
     },
   });
+
+  // Search function
+  const performSearch = useCallback(async (query: string) => {
+    if (!user || !query.trim()) {
+      setSearchResults([]);
+      setSearchTotalCount(0);
+      setIsSearching(false);
+      return;
+    }
+
+    setSearchLoading(true);
+    setIsSearching(true);
+    try {
+      const response = await financeClient.searchTransactions({
+        userId: user.uid,
+        query,
+        type: TransactionType.EXPENSE,
+        pageSize: 50,
+      });
+      setSearchResults(response.results);
+      setSearchTotalCount(response.totalCount);
+    } catch {
+      setSearchResults([]);
+      setSearchTotalCount(0);
+    } finally {
+      setSearchLoading(false);
+    }
+  }, [user]);
+
+  // Debounced search on query change
+  useEffect(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+    if (!searchQuery.trim()) {
+      setSearchResults([]);
+      setSearchTotalCount(0);
+      setIsSearching(false);
+      return;
+    }
+    debounceRef.current = setTimeout(() => {
+      performSearch(searchQuery);
+    }, 300);
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, [searchQuery, performSearch]);
 
   // Add event listeners for shift key
   useEffect(() => {
@@ -290,8 +401,109 @@ export default function ExpenseList({ limit, filterDate, onClearFilter }: Expens
     'annually'
   ];
 
-  const displayExpenses = filteredExpenses;
-  const visibleExpenses = limit ? displayExpenses.slice(0, limit) : displayExpenses;
+  // Pagination helpers
+  const getPageNumbers = () => {
+    const pages: (number | 'ellipsis')[] = [];
+    if (totalPages <= 7) {
+      for (let i = 1; i <= totalPages; i++) pages.push(i);
+    } else {
+      pages.push(1);
+      if (currentPage > 3) pages.push('ellipsis');
+      const start = Math.max(2, currentPage - 1);
+      const end = Math.min(totalPages - 1, currentPage + 1);
+      for (let i = start; i <= end; i++) pages.push(i);
+      if (currentPage < totalPages - 2) pages.push('ellipsis');
+      pages.push(totalPages);
+    }
+    return pages;
+  };
+
+  const showPagination = !limit && !isSearching && totalPages > 1;
+  const paginationStart = (currentPage - 1) * PAGE_SIZE + 1;
+  const paginationEnd = Math.min(currentPage * PAGE_SIZE, filteredExpenses.length);
+
+  // Render a row for either a full Expense or a search display item
+  const renderMobileCard = (item: { id: string; description: string; category: string; amount: number; date: Date }, index: number, isSearchResult: boolean) => (
+    <div
+      key={item.id}
+      className="flex items-start gap-3 p-3 rounded-lg border bg-background active:bg-accent/50 transition-colors cursor-pointer"
+      onClick={() => router.push(`/personal/expenses/${item.id}/`)}
+    >
+      {/* Checkbox - only in browse mode */}
+      {!isSearchResult && (
+        <div
+          className="pt-0.5 shrink-0"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <input
+            type="checkbox"
+            checked={selectedExpenseIds.has(item.id)}
+            onChange={() => handleToggleSelect(item.id, index)}
+            className="w-4 h-4 cursor-pointer"
+          />
+        </div>
+      )}
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <p className="font-medium text-sm truncate">{item.description}</p>
+            <p className="text-xs text-muted-foreground mt-0.5">{formatShortDate(item.date)}</p>
+          </div>
+          <div className="text-right shrink-0">
+            <p className="font-semibold text-sm">{formatCurrency(item.amount)}</p>
+            {!isSearchResult && (item as Expense).isTaxDeductible && (
+              <Badge variant="outline" className="text-[10px] border-green-500 text-green-600 px-1 py-0">
+                Tax
+              </Badge>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-1.5 mt-2 flex-wrap">
+          <Badge
+            className="text-[10px] px-1.5 py-0"
+            style={getInstrumentBadgeStyle(getCategoryColor(item.category as ExpenseCategory))}
+          >
+            {item.category}
+          </Badge>
+          {!isSearchResult && (
+            <Badge
+              className="text-[10px] px-1.5 py-0"
+              style={getInstrumentBadgeStyle(getFrequencyColor((item as Expense).frequency))}
+            >
+              {formatFrequency((item as Expense).frequency)}
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      {/* Actions - only in browse mode */}
+      {!isSearchResult && (
+        <div
+          className="flex flex-col gap-2 shrink-0"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-10 w-10 p-0"
+            onClick={() => handleEdit(item as Expense)}
+          >
+            <Pencil className="h-3 w-3" />
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            className="h-10 w-10 p-0"
+            onClick={() => handleDeleteClick(item.id)}
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
 
   return (
     <>
@@ -300,7 +512,7 @@ export default function ExpenseList({ limit, filterDate, onClearFilter }: Expens
           <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2">
             <CardTitle className="text-lg sm:text-xl font-bold">Expense History</CardTitle>
             <div className="flex gap-2">
-              {selectedExpenseIds.size > 0 && (
+              {!isSearching && selectedExpenseIds.size > 0 && (
                 <Button
                   variant="destructive"
                   onClick={handleBatchDelete}
@@ -313,7 +525,50 @@ export default function ExpenseList({ limit, filterDate, onClearFilter }: Expens
               )}
             </div>
           </div>
-          {filterDate && (
+
+          {/* Search bar - hidden in dashboard preview mode */}
+          {!limit && (
+            <div className="relative mt-2">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Search expenses..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-9 pr-9"
+              />
+              {searchQuery && (
+                <button
+                  onClick={() => {
+                    setSearchQuery('');
+                    setSearchResults([]);
+                    setSearchTotalCount(0);
+                    setIsSearching(false);
+                  }}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+          )}
+
+          {/* Search status */}
+          {isSearching && (
+            <div className="flex items-center gap-2 mt-2 text-sm text-muted-foreground">
+              {searchLoading ? (
+                <>
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  <span>Searching...</span>
+                </>
+              ) : (
+                <span>
+                  {searchTotalCount} result{searchTotalCount !== 1 ? 's' : ''} for &ldquo;{searchQuery}&rdquo;
+                </span>
+              )}
+            </div>
+          )}
+
+          {filterDate && !isSearching && (
             <div className="flex items-center gap-2 mt-2 p-2 rounded-md bg-accent/50 text-sm">
               <CalendarDays className="h-4 w-4 text-muted-foreground shrink-0" />
               <span className="text-xs sm:text-sm">
@@ -341,91 +596,24 @@ export default function ExpenseList({ limit, filterDate, onClearFilter }: Expens
           )}
         </CardHeader>
         <CardContent>
-          {displayExpenses.length === 0 ? (
+          {!isSearching && displayExpenses.length === 0 ? (
             <p className="text-center text-muted-foreground py-4">
               {filterDate ? 'No expenses found for this date.' : 'No expenses recorded yet.'}
+            </p>
+          ) : isSearching && searchResults.length === 0 && !searchLoading ? (
+            <p className="text-center text-muted-foreground py-4">
+              No results found for &ldquo;{searchQuery}&rdquo;
             </p>
           ) : (
             <>
               {/* Mobile Card View */}
               <div className="md:hidden space-y-2">
-                {visibleExpenses.map((expense, index) => (
-                  <div
-                    key={expense.id}
-                    className="flex items-start gap-3 p-3 rounded-lg border bg-background active:bg-accent/50 transition-colors cursor-pointer"
-                    onClick={() => router.push(`/personal/expenses/${expense.id}/`)}
-                  >
-                    {/* Checkbox */}
-                    <div
-                      className="pt-0.5 shrink-0"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={selectedExpenseIds.has(expense.id)}
-                        onChange={() => handleToggleSelect(expense.id, index)}
-                        className="w-4 h-4 cursor-pointer"
-                      />
-                    </div>
-
-                    {/* Content */}
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-start justify-between gap-2">
-                        <div className="min-w-0">
-                          <p className="font-medium text-sm truncate">{expense.description}</p>
-                          <p className="text-xs text-muted-foreground mt-0.5">{formatShortDate(expense.date)}</p>
-                        </div>
-                        <div className="text-right shrink-0">
-                          <p className="font-semibold text-sm">{formatCurrency(expense.amount)}</p>
-                          {expense.isTaxDeductible && (
-                            <Badge variant="outline" className="text-[10px] border-green-500 text-green-600 px-1 py-0">
-                              Tax
-                            </Badge>
-                          )}
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-1.5 mt-2 flex-wrap">
-                        <Badge
-                          className="text-[10px] px-1.5 py-0"
-                          style={getInstrumentBadgeStyle(getCategoryColor(expense.category))}
-                        >
-                          {expense.category}
-                        </Badge>
-                        <Badge
-                          className="text-[10px] px-1.5 py-0"
-                          style={getInstrumentBadgeStyle(getFrequencyColor(expense.frequency))}
-                        >
-                          {formatFrequency(expense.frequency)}
-                        </Badge>
-                      </div>
-                    </div>
-
-                    {/* Actions */}
-                    <div
-                      className="flex flex-col gap-2 shrink-0"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-10 w-10 p-0"
-                        onClick={() => handleEdit(expense)}
-                      >
-                        <Pencil className="h-3 w-3" />
-                      </Button>
-                      <Button
-                        variant="destructive"
-                        size="sm"
-                        className="h-10 w-10 p-0"
-                        onClick={() => handleDeleteClick(expense.id)}
-                      >
-                        <Trash2 className="h-3 w-3" />
-                      </Button>
-                    </div>
-                  </div>
-                ))}
-                {/* Mobile select all */}
-                {displayExpenses.length > 1 && (
+                {isSearching
+                  ? searchDisplayItems.map((item, index) => renderMobileCard(item, index, true))
+                  : paginatedExpenses.map((expense, index) => renderMobileCard(expense, index, false))
+                }
+                {/* Mobile select all - only in browse mode */}
+                {!isSearching && displayExpenses.length > 1 && !limit && (
                   <div className="flex items-center justify-between pt-2 border-t">
                     <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
                       <input
@@ -445,101 +633,171 @@ export default function ExpenseList({ limit, filterDate, onClearFilter }: Expens
                 <Table>
                   <TableHeader>
                     <TableRow className="hover:bg-transparent">
-                      <TableHead className="w-[50px]">
-                        <input
-                          type="checkbox"
-                          checked={displayExpenses.length > 0 && selectedExpenseIds.size === displayExpenses.length}
-                          onChange={handleSelectAll}
-                          className="w-4 h-4"
-                        />
-                      </TableHead>
+                      {!isSearching && (
+                        <TableHead className="w-[50px]">
+                          <input
+                            type="checkbox"
+                            checked={displayExpenses.length > 0 && selectedExpenseIds.size === displayExpenses.length}
+                            onChange={handleSelectAll}
+                            className="w-4 h-4"
+                          />
+                        </TableHead>
+                      )}
                       <TableHead>Date</TableHead>
                       <TableHead>Description</TableHead>
                       <TableHead>Category</TableHead>
-                      <TableHead>Frequency</TableHead>
+                      {!isSearching && <TableHead>Frequency</TableHead>}
                       <TableHead className="text-right">Amount</TableHead>
-                      <TableHead className="w-[100px] text-right">Actions</TableHead>
+                      {!isSearching && <TableHead className="w-[100px] text-right">Actions</TableHead>}
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {visibleExpenses.map((expense, index) => (
-                      <TableRow
-                        key={expense.id}
-                        className="cursor-pointer"
-                        onClick={() => router.push(`/personal/expenses/${expense.id}/`)}
-                      >
-                        <TableCell onClick={(e) => e.stopPropagation()}>
-                          <input
-                            type="checkbox"
-                            checked={selectedExpenseIds.has(expense.id)}
-                            onChange={() => handleToggleSelect(expense.id, index)}
-                            className="w-4 h-4 cursor-pointer"
-                          />
-                        </TableCell>
-                        <TableCell>{formatDate(expense.date)}</TableCell>
-                        <TableCell className="font-medium">{expense.description}</TableCell>
-                        <TableCell>
-                          <Badge
-                            style={getInstrumentBadgeStyle(getCategoryColor(expense.category))}
+                    {isSearching
+                      ? searchDisplayItems.map((item) => (
+                          <TableRow
+                            key={item.id}
+                            className="cursor-pointer"
+                            onClick={() => router.push(`/personal/expenses/${item.id}/`)}
                           >
-                            {expense.category}
-                          </Badge>
-                        </TableCell>
-                        <TableCell>
-                          <Badge
-                            style={getInstrumentBadgeStyle(getFrequencyColor(expense.frequency))}
-                          >
-                            {formatFrequency(expense.frequency)}
-                          </Badge>
-                        </TableCell>
-                        <TableCell className="text-right font-medium">
-                          <div className="flex items-center justify-end gap-1.5">
-                            {expense.isTaxDeductible && (
-                              <Badge variant="outline" className="text-xs border-green-500 text-green-600">
-                                Tax
-                              </Badge>
-                            )}
-                            {formatCurrency(expense.amount)}
-                          </div>
-                        </TableCell>
-                        <TableCell className="w-[140px] text-right" onClick={(e) => e.stopPropagation()}>
-                          <div className="flex justify-end gap-1">
-                            {canShare && (
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                className="h-8 w-8 p-0"
-                                onClick={() => handleShare(expense)}
-                                title="Share with group"
+                            <TableCell>{formatDate(item.date)}</TableCell>
+                            <TableCell className="font-medium">{item.description}</TableCell>
+                            <TableCell>
+                              <Badge
+                                style={getInstrumentBadgeStyle(getCategoryColor(item.category as ExpenseCategory))}
                               >
-                                <Share2 className="h-4 w-4" />
-                              </Button>
-                            )}
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              className="h-8 w-8 p-0 bg-zinc-900 hover:bg-zinc-800 text-white"
-                              onClick={() => handleEdit(expense)}
-                              title="Edit expense"
-                            >
-                              <Pencil className="h-4 w-4" />
-                            </Button>
-                            <Button
-                              variant="destructive"
-                              size="sm"
-                              className="h-8 w-8 p-0"
-                              onClick={() => handleDeleteClick(expense.id)}
-                              title="Delete expense"
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </Button>
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                    ))}
+                                {item.category}
+                              </Badge>
+                            </TableCell>
+                            <TableCell className="text-right font-medium">
+                              {formatCurrency(item.amount)}
+                            </TableCell>
+                          </TableRow>
+                        ))
+                      : paginatedExpenses.map((expense, index) => (
+                          <TableRow
+                            key={expense.id}
+                            className="cursor-pointer"
+                            onClick={() => router.push(`/personal/expenses/${expense.id}/`)}
+                          >
+                            <TableCell onClick={(e) => e.stopPropagation()}>
+                              <input
+                                type="checkbox"
+                                checked={selectedExpenseIds.has(expense.id)}
+                                onChange={() => handleToggleSelect(expense.id, index)}
+                                className="w-4 h-4 cursor-pointer"
+                              />
+                            </TableCell>
+                            <TableCell>{formatDate(expense.date)}</TableCell>
+                            <TableCell className="font-medium">{expense.description}</TableCell>
+                            <TableCell>
+                              <Badge
+                                style={getInstrumentBadgeStyle(getCategoryColor(expense.category))}
+                              >
+                                {expense.category}
+                              </Badge>
+                            </TableCell>
+                            <TableCell>
+                              <Badge
+                                style={getInstrumentBadgeStyle(getFrequencyColor(expense.frequency))}
+                              >
+                                {formatFrequency(expense.frequency)}
+                              </Badge>
+                            </TableCell>
+                            <TableCell className="text-right font-medium">
+                              <div className="flex items-center justify-end gap-1.5">
+                                {expense.isTaxDeductible && (
+                                  <Badge variant="outline" className="text-xs border-green-500 text-green-600">
+                                    Tax
+                                  </Badge>
+                                )}
+                                {formatCurrency(expense.amount)}
+                              </div>
+                            </TableCell>
+                            <TableCell className="w-[140px] text-right" onClick={(e) => e.stopPropagation()}>
+                              <div className="flex justify-end gap-1">
+                                {canShare && (
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    className="h-8 w-8 p-0"
+                                    onClick={() => handleShare(expense)}
+                                    title="Share with group"
+                                  >
+                                    <Share2 className="h-4 w-4" />
+                                  </Button>
+                                )}
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  className="h-8 w-8 p-0 bg-zinc-900 hover:bg-zinc-800 text-white"
+                                  onClick={() => handleEdit(expense)}
+                                  title="Edit expense"
+                                >
+                                  <Pencil className="h-4 w-4" />
+                                </Button>
+                                <Button
+                                  variant="destructive"
+                                  size="sm"
+                                  className="h-8 w-8 p-0"
+                                  onClick={() => handleDeleteClick(expense.id)}
+                                  title="Delete expense"
+                                >
+                                  <Trash2 className="h-4 w-4" />
+                                </Button>
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        ))
+                    }
                   </TableBody>
                 </Table>
               </div>
+
+              {/* Pagination Controls */}
+              {showPagination && (
+                <div className="flex flex-col sm:flex-row items-center justify-between gap-3 pt-4 border-t mt-4">
+                  <span className="text-sm text-muted-foreground">
+                    Showing {paginationStart}&ndash;{paginationEnd} of {filteredExpenses.length}
+                  </span>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 w-8 p-0"
+                      onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                      disabled={currentPage === 1}
+                    >
+                      <ChevronLeft className="h-4 w-4" />
+                    </Button>
+                    {getPageNumbers().map((page, i) =>
+                      page === 'ellipsis' ? (
+                        <span key={`ellipsis-${i}`} className="px-1 text-muted-foreground">
+                          &hellip;
+                        </span>
+                      ) : (
+                        <Button
+                          key={page}
+                          variant={page === currentPage ? 'default' : 'outline'}
+                          size="sm"
+                          className="h-8 w-8 p-0"
+                          onClick={() => setCurrentPage(page)}
+                        >
+                          {page}
+                        </Button>
+                      )
+                    )}
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 w-8 p-0"
+                      onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                      disabled={currentPage === totalPages}
+                    >
+                      <ChevronRight className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              )}
             </>
           )}
         </CardContent>

--- a/web/src/lib/chat/system-prompt.ts
+++ b/web/src/lib/chat/system-prompt.ts
@@ -32,6 +32,8 @@ You MUST proactively call tools to fully answer questions. NEVER respond with "W
 **Examples of correct behavior:**
 - User: "What did I spend the most on?" → Call \`get_spending_summary\` AND \`list_expenses\` to get both category breakdown and top individual expenses, then synthesize the answer.
 - User: "Am I over budget?" → Call \`get_budget_progress\` to get all budgets with progress, then analyze which are over/under.
+- User: "How's my groceries budget?" → Call \`get_budget_progress\` with query="groceries" to find and report on that specific budget.
+- User: "How's my emergency fund going?" → Call \`list_goals\` with query="emergency fund" to find and report on that goal's progress.
 - User: "How are my finances?" → Call \`get_spending_summary\`, \`get_budget_progress\`, \`list_incomes\`, and \`list_goals\` to provide a comprehensive overview.
 - User: "Compare my spending this month vs last" → Call \`list_expenses\` for both date ranges (or \`get_category_comparison\` if Pro), then compare.
 ${ctx.isPro ? '- User: "What can I claim on tax?" → Call `get_tax_summary` for the current FY overview, plus `list_deductible_expenses` for the detail.\n- User: "Find my deductions" → Call `classify_tax_deductibility` in batch mode to AI-classify expenses.\n- User: "Mark X as deductible" → `search_transactions` to find X, then `update_tax_deductibility` with confirmed=false/true pattern.' : ''}
@@ -75,9 +77,12 @@ ${ctx.isPro ? '9. Pro analytics and tax tools are available — use them for ric
 - **"How much did I spend this month/week/period?"** → \`get_spending_summary\` for category breakdown + totals
 - **"Top expenses" / "Biggest purchases"** → \`list_expenses\` with date range, sorted results
 - **"Budget status" / "Am I over budget?"** → \`get_budget_progress\`
+- **"Find budget X" / "Groceries budget"** → \`get_budget_progress\` with query (e.g. query="groceries")
 - **"My income" / "How much do I earn?"** → \`list_incomes\`
 - **"Goals progress"** → \`list_goals\`
+- **"Find goal X" / "Emergency fund goal"** → \`list_goals\` with query (e.g. query="emergency fund")
 - **"Financial overview" / "How are my finances?"** → Call MULTIPLE tools: \`get_spending_summary\` + \`get_budget_progress\` + \`list_incomes\` + \`list_goals\`
+- **"Search everything about X"** → Call \`search_transactions\` + \`list_goals\` + \`get_budget_progress\` all with the same query to search across all entity types
 - **"Find and delete/update X"** → \`search_transactions\` first, then mutation tool with confirmed=false, then confirmed=true after user approval
 - **"Delete duplicates" / "Remove all but one"** → \`search_transactions\` to find matches, pick the best one to keep, then \`delete_expenses_batch\` with the rest (NOT multiple individual deletes)
 ${ctx.isPro ? `- **"Compare categories" / "Spending trends"** → \`get_category_comparison\`


### PR DESCRIPTION
## Summary
- **Cmd+K global search**: Expand `SearchCommandPalette` to search goals and budgets client-side alongside existing Algolia-backed transaction search. Goals show with Target icon (amber), budgets with Wallet icon (blue). Type filter hides goals/budgets when set to Expenses or Income.
- **ExpenseList inline search**: Add search bar with 300ms debounce and cursor-based pagination (25/page) to expense history table.
- **Chat tools**: Add optional `query` parameter to `list_goals` and `get_budget_progress` chat tools for name/description substring filtering. Update system prompt with search examples.

## Test plan
- [ ] Cmd+K → type a goal name → appears in "Goals" group
- [ ] Cmd+K → type a budget name → appears in "Budgets" group
- [ ] Cmd+K → set Type filter to "Expenses" → goals/budgets hidden
- [ ] Click a goal result → navigates to `/personal/goals/`
- [ ] Click a budget result → navigates to `/personal/budgets/`
- [ ] ExpenseList search bar filters expenses via backend search
- [ ] Chat: "How's my groceries budget?" → uses `get_budget_progress` with query
- [ ] Chat: "Emergency fund goal?" → uses `list_goals` with query
- [ ] `npx tsc --noEmit` passes with no new errors