### PR TITLE
fix: eliminate background polling — Firestore onSnapshot listeners

### DIFF
--- a/web/src/app/context/NotificationContext.tsx
+++ b/web/src/app/context/NotificationContext.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { createContext, useContext, useState, useEffect, useCallback, useRef, ReactNode, useMemo } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, ReactNode, useMemo } from 'react';
+import { collection, onSnapshot, query, where } from 'firebase/firestore';
 import { financeClient } from '@/lib/financeService';
+import { db } from '@/lib/firebase';
 import type { Notification, NotificationPreferences } from '@/gen/pfinance/v1/types_pb';
 import { useAuth } from './AuthWithAdminContext';
 
@@ -25,15 +27,6 @@ interface NotificationContextType {
 const NotificationContext = createContext<NotificationContextType | undefined>(undefined);
 
 // ============================================================================
-// Polling intervals
-// ============================================================================
-
-// Default: poll every 60 seconds
-const POLL_INTERVAL_MS = 60_000;
-// When FCM push is active, poll infrequently as a safety net
-const POLL_INTERVAL_PUSH_MS = 300_000; // 5 minutes
-
-// ============================================================================
 // Provider Component
 // ============================================================================
 
@@ -44,23 +37,19 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [preferences, setPreferences] = useState<NotificationPreferences | null>(null);
-  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const isAuthenticated = !!user;
   const userId = user?.uid || '';
 
   // ── Fetch unread count ─────────────────────────────────────────────────
+  // No-op: unread count is maintained by the Firestore onSnapshot listener
+  // below. This is retained on the public API surface for callers that
+  // expect a manual refresh hook (e.g. after an action they took elsewhere)
+  // but the listener already pushes updates in real-time.
 
   const refreshUnreadCount = useCallback(async () => {
-    if (!isAuthenticated || !userId) return;
-
-    try {
-      const response = await financeClient.getUnreadNotificationCount({ userId });
-      setUnreadCount(response.count);
-    } catch (e) {
-      console.error('[NotificationContext] Failed to fetch unread count:', e);
-    }
-  }, [isAuthenticated, userId]);
+    // intentionally empty — see useEffect with onSnapshot below
+  }, []);
 
   // ── Load full notification list ────────────────────────────────────────
 
@@ -165,9 +154,13 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
     }
   }, [isAuthenticated, userId, preferences]);
 
-  // ── Poll unread count ──────────────────────────────────────────────────
-  // Uses a longer interval when FCM push is active (push delivers updates
-  // in real-time, polling is just a safety net).
+  // ── Real-time unread count via Firestore listener ──────────────────────
+  // Replaces a 60s polling loop that kept a Cloud Run instance permanently
+  // alive (~$65/mo for one Chrome tab). The backend writes to the
+  // `notifications` collection (see backend internal/store/firestore.go);
+  // we listen on `where(UserId == userId AND IsRead == false)` and count
+  // the snapshot size client-side. Zero backend round-trips, instant
+  // updates when a notification is created or marked read.
 
   useEffect(() => {
     if (!isAuthenticated || !userId) {
@@ -178,39 +171,30 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
       return;
     }
 
-    // Initial fetch
-    refreshUnreadCount();
     loadPreferences();
 
-    // Determine polling interval: if FCM push is registered, poll infrequently
-    let interval = POLL_INTERVAL_MS;
-    try {
-      if (localStorage.getItem('pfinance_fcm_token')) {
-        interval = POLL_INTERVAL_PUSH_MS;
-      }
-    } catch {
-      // localStorage unavailable (SSR/incognito)
+    if (!db) {
+      // Firestore not configured (e.g. SSR build without env vars). Skip
+      // listener; the action handlers still work via RPC.
+      return;
     }
 
-    // Set up polling
-    pollIntervalRef.current = setInterval(() => {
-      refreshUnreadCount();
-    }, interval);
+    const q = query(
+      collection(db, 'notifications'),
+      where('UserId', '==', userId),
+      where('IsRead', '==', false),
+    );
 
-    // Listen for foreground FCM push messages — refresh immediately
-    const handleFCMMessage = () => {
-      refreshUnreadCount();
-    };
-    window.addEventListener('fcm-foreground-message', handleFCMMessage);
+    const unsubscribe = onSnapshot(
+      q,
+      (snap) => setUnreadCount(snap.size),
+      (err) => console.error('[NotificationContext] Firestore listener error:', err),
+    );
 
     return () => {
-      window.removeEventListener('fcm-foreground-message', handleFCMMessage);
-      if (pollIntervalRef.current) {
-        clearInterval(pollIntervalRef.current);
-        pollIntervalRef.current = null;
-      }
+      unsubscribe();
     };
-  }, [isAuthenticated, userId, refreshUnreadCount, loadPreferences]);
+  }, [isAuthenticated, userId, loadPreferences]);
 
   // ── Context value ──────────────────────────────────────────────────────
 

--- a/web/src/app/context/multiuser/hooks/useGroupExpenses.ts
+++ b/web/src/app/context/multiuser/hooks/useGroupExpenses.ts
@@ -6,7 +6,9 @@
 
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { User } from 'firebase/auth';
+import { collection, onSnapshot, query, where } from 'firebase/firestore';
 import { financeClient } from '@/lib/financeService';
+import { db } from '@/lib/firebase';
 import { 
   Expense,
   ExpenseAllocation,
@@ -100,18 +102,42 @@ export function useGroupExpenses({ user, activeGroup }: UseGroupExpensesOptions)
     refreshGroupExpenses().finally(() => setLoading(false));
   }, [activeGroup, refreshGroupExpenses]);
 
-  // Set up polling for real-time updates on shared pages
+  // Real-time updates via Firestore listener — replaces a 5s polling loop
+  // that hammered listExpenses every 5 seconds while on /shared pages.
+  // Backend writes to the `groupExpenses` collection (see backend
+  // internal/store/firestore.go ListExpenses); we listen on
+  // `where(GroupId == activeGroup.id)` and call the existing RPC refresh
+  // ONLY when Firestore reports an actual change. Under steady state
+  // (no changes) this is zero round-trips — was 720 RPCs/hour before.
   useEffect(() => {
-    if (!activeGroup || typeof window === 'undefined') return;
+    if (!activeGroup || typeof window === 'undefined' || !db) return;
 
     const isSharedPage = window.location.pathname.startsWith('/shared');
     if (!isSharedPage) return;
 
-    const intervalId = setInterval(() => {
-      refreshGroupExpenses();
-    }, 5000);
+    const q = query(
+      collection(db, 'groupExpenses'),
+      where('GroupId', '==', activeGroup.id),
+    );
 
-    return () => clearInterval(intervalId);
+    // Skip the very first snapshot — it's just the current state, which the
+    // dedicated load-on-group-change effect above has already fetched.
+    let firstSnapshot = true;
+    const unsubscribe = onSnapshot(
+      q,
+      () => {
+        if (firstSnapshot) {
+          firstSnapshot = false;
+          return;
+        }
+        refreshGroupExpenses();
+      },
+      (err) => console.error('groupExpenses listener error:', err),
+    );
+
+    return () => {
+      unsubscribe();
+    };
   }, [activeGroup, refreshGroupExpenses]);
 
   const addGroupExpense = useCallback(async (


### PR DESCRIPTION
## Summary

Two background polling loops were keeping the Cloud Run instance permanently alive, costing **~\$65/mo** for one Chrome tab to render a notification badge.

| Site | Was | Now |
|---|---|---|
| \`NotificationContext\` | \`getUnreadNotificationCount\` every 60s | \`onSnapshot(notifications, where(UserId, ==, userId), where(IsRead, ==, false))\` — count = snap.size, zero RPCs |
| \`useGroupExpenses\` | \`listExpenses\` every 5s on /shared | \`onSnapshot(groupExpenses, where(GroupId, ==, activeGroup.id))\` triggers refetch only when Firestore reports a change |

Steady-state RPC calls: **was ~720/hour, now ~0**.

## Why this works
Backend already writes to these Firestore collections (see \`backend/internal/store/firestore.go\` — \`GetUnreadNotificationCount\` line 1997 and \`ListExpenses\` line 168). Frontend reads from the same source of truth without round-tripping through Cloud Run.

## Cost impact
- Cloud Run pfinance-backend instance-hours: returns ~\$65/mo to the budget
- The service still cold-starts on real user actions (RPC writes) — that's the correct behavior; the polling was masking it
- Cold-start cost on first action of a session is negligible vs 24/7 keep-warm

## Not in scope
3 job-status polling sites remain (tax eval, bulk upload, smart expense entry). They use in-memory backend job storage so converting requires backend changes (Firestore-backed job state). Those are short-lived (max 90s during user-initiated work) so cost impact is minimal vs the 24/7 background pollers fixed here.

## Test plan
- [x] tsc --noEmit — clean
- [ ] After deploy: confirm pfinance-backend Cloud Run instance count drops to 0 outside user activity
- [ ] After deploy: confirm notification badge updates in real-time when a notification is created server-side
- [ ] After deploy: confirm shared expenses list updates when another user in the group adds/edits