### PR TITLE
fix(jobs): replace remaining job-status polling with Firestore onSnapshot listeners

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 
 	"cloud.google.com/go/firestore"
 	"connectrpc.com/connect"
+	pfinancev1 "github.com/castlemilk/pfinance/backend/gen/pfinance/v1"
 	"github.com/castlemilk/pfinance/backend/gen/pfinance/v1/pfinancev1connect"
 	"github.com/castlemilk/pfinance/backend/internal/auth"
 	"github.com/castlemilk/pfinance/backend/internal/extraction"
@@ -44,6 +45,7 @@ func main() {
 
 	var storeImpl store.Store
 	var firebaseAuth *auth.FirebaseAuth
+	var firestoreClient *firestore.Client // nil in memory-store mode; used for job-state mirroring below
 
 	if useMemoryStore {
 		log.Println("Using in-memory store for local development")
@@ -60,7 +62,8 @@ func main() {
 			projectID = "pfinance-app-1748773335"
 		}
 
-		firestoreClient, err := firestore.NewClient(ctx, projectID)
+		var err error
+		firestoreClient, err = firestore.NewClient(ctx, projectID)
 		if err != nil {
 			log.Fatalf("Failed to create Firestore client: %v", err)
 		}
@@ -108,8 +111,39 @@ func main() {
 	// Wire statement store for two-phase extraction dedup
 	extractionSvc.SetStatementStore(storeImpl)
 
+	// Mirror job state to Firestore so the frontend can listen via
+	// onSnapshot instead of polling getExtractionJob every 1.5s. The
+	// in-memory store remains the RPC source of truth; Firestore is a
+	// passive sink for real-time UI updates. Errors are logged and
+	// non-fatal — the existing GetExtractionJob RPC always works.
+	// Skipped in memory-store / local mode where there is no Firestore.
+	if firestoreClient != nil {
+		fsClient := firestoreClient
+		extractionSvc.SetJobPublisher(func(job *pfinancev1.ExtractionJob) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if _, err := fsClient.Collection("extractionJobs").Doc(job.Id).Set(ctx, job); err != nil {
+				log.Printf("[extraction] failed to publish job %s to Firestore: %v", job.Id, err)
+			}
+		})
+	}
+
 	service.SetExtractionService(extractionSvc)
 	log.Printf("✅ Document extraction enabled (ML service: %s)", mlServiceURL)
+
+	// Mirror tax-eval job state to Firestore (same pattern as extraction
+	// jobs above) so the eval-progress UI listens via onSnapshot instead of
+	// polling getTaxEvalJob every 2s.
+	if firestoreClient != nil {
+		fsClient := firestoreClient
+		service.SetTaxEvalJobPublisher(func(job *pfinancev1.TaxEvalJob) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if _, err := fsClient.Collection("taxEvalJobs").Doc(job.Id).Set(ctx, job); err != nil {
+				log.Printf("[taxeval] failed to publish job %s to Firestore: %v", job.Id, err)
+			}
+		})
+	}
 
 	// Keep the Modal ML container warm with a periodic health-check ping.
 	// Modal shuts containers down after 60s of inactivity; pinging every 45s

--- a/backend/internal/extraction/jobstore.go
+++ b/backend/internal/extraction/jobstore.go
@@ -9,12 +9,19 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// JobPublisher is an optional sink that receives every Create/Update so an
+// external store (e.g. Firestore) can mirror job state for real-time clients.
+// Errors are logged but never block the in-memory store update — the RPC path
+// (GetJob) continues to work even if the publisher is broken or absent.
+type JobPublisher func(job *pfinancev1.ExtractionJob)
+
 // JobStore manages in-memory async extraction jobs.
 type JobStore struct {
-	mu   sync.RWMutex
-	jobs map[string]*pfinancev1.ExtractionJob
-	ttl  time.Duration
-	done chan struct{}
+	mu      sync.RWMutex
+	jobs    map[string]*pfinancev1.ExtractionJob
+	ttl     time.Duration
+	done    chan struct{}
+	publish JobPublisher // optional; called after every Create/Update
 }
 
 // NewJobStore creates a new job store with background cleanup.
@@ -28,14 +35,27 @@ func NewJobStore(ttl time.Duration) *JobStore {
 	return js
 }
 
+// SetPublisher installs a publisher that receives every Create/Update. Replaces
+// any previous publisher. Pass nil to disable. Safe to call before clients
+// start hitting the store; for live wiring, prefer constructor-time injection.
+func (js *JobStore) SetPublisher(p JobPublisher) {
+	js.mu.Lock()
+	defer js.mu.Unlock()
+	js.publish = p
+}
+
 // Create stores a new extraction job.
 func (js *JobStore) Create(job *pfinancev1.ExtractionJob) error {
 	if job.Id == "" {
 		return fmt.Errorf("job ID is required")
 	}
 	js.mu.Lock()
-	defer js.mu.Unlock()
 	js.jobs[job.Id] = job
+	publish := js.publish
+	js.mu.Unlock()
+	if publish != nil {
+		publish(job)
+	}
 	return nil
 }
 
@@ -53,11 +73,16 @@ func (js *JobStore) Get(id string) (*pfinancev1.ExtractionJob, error) {
 // Update modifies an existing job.
 func (js *JobStore) Update(job *pfinancev1.ExtractionJob) error {
 	js.mu.Lock()
-	defer js.mu.Unlock()
 	if _, ok := js.jobs[job.Id]; !ok {
+		js.mu.Unlock()
 		return fmt.Errorf("job not found: %s", job.Id)
 	}
 	js.jobs[job.Id] = job
+	publish := js.publish
+	js.mu.Unlock()
+	if publish != nil {
+		publish(job)
+	}
 	return nil
 }
 

--- a/backend/internal/extraction/service.go
+++ b/backend/internal/extraction/service.go
@@ -109,6 +109,13 @@ func (s *ExtractionService) SetMerchantLookup(lookup MerchantLookup) {
 	s.merchantLookup = lookup
 }
 
+// SetJobPublisher wires an external publisher (e.g. Firestore) into the job
+// store. Every Create/Update fires the publisher in addition to the in-memory
+// write — the existing GetJob RPC path is unchanged.
+func (s *ExtractionService) SetJobPublisher(p JobPublisher) {
+	s.jobStore.SetPublisher(p)
+}
+
 // StartWarmupScheduler pings the ML service every interval to prevent cold starts.
 // Modal's serverless containers shut down after 60s of inactivity; a regular
 // health-check keeps the container warm so the first real request isn't delayed

--- a/backend/internal/service/taxeval_service.go
+++ b/backend/internal/service/taxeval_service.go
@@ -19,18 +19,33 @@ import (
 
 // taxEvalJobStore manages in-memory async tax eval jobs.
 type taxEvalJobStore struct {
-	mu   sync.RWMutex
-	jobs map[string]*pfinancev1.TaxEvalJob
+	mu      sync.RWMutex
+	jobs    map[string]*pfinancev1.TaxEvalJob
+	publish func(job *pfinancev1.TaxEvalJob) // optional; mirrors state to Firestore
 }
 
 var evalJobs = &taxEvalJobStore{
 	jobs: make(map[string]*pfinancev1.TaxEvalJob),
 }
 
+// SetTaxEvalJobPublisher installs a publisher that mirrors every Create/Update
+// to an external sink (Firestore). The frontend listens via onSnapshot instead
+// of polling getTaxEvalJob every 2s. Errors are the publisher's responsibility
+// to log; the in-memory store update never blocks on the publisher.
+func SetTaxEvalJobPublisher(p func(job *pfinancev1.TaxEvalJob)) {
+	evalJobs.mu.Lock()
+	defer evalJobs.mu.Unlock()
+	evalJobs.publish = p
+}
+
 func (s *taxEvalJobStore) create(job *pfinancev1.TaxEvalJob) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.jobs[job.Id] = job
+	publish := s.publish
+	s.mu.Unlock()
+	if publish != nil {
+		publish(job)
+	}
 }
 
 func (s *taxEvalJobStore) get(id string) (*pfinancev1.TaxEvalJob, bool) {
@@ -42,8 +57,12 @@ func (s *taxEvalJobStore) get(id string) (*pfinancev1.TaxEvalJob, bool) {
 
 func (s *taxEvalJobStore) update(job *pfinancev1.TaxEvalJob) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.jobs[job.Id] = job
+	publish := s.publish
+	s.mu.Unlock()
+	if publish != nil {
+		publish(job)
+	}
 }
 
 // RunTaxEval starts an async tax evaluation job.

--- a/web/src/app/(app)/personal/tax/eval/page.tsx
+++ b/web/src/app/(app)/personal/tax/eval/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState, useRef, useCallback } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -371,40 +373,54 @@ export default function TaxEvalPage() {
   const [job, setJob] = useState<TaxEvalJob | null>(null);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const unsubRef = useRef<(() => void) | null>(null);
 
-  const stopPolling = useCallback(() => {
-    if (pollRef.current) {
-      clearInterval(pollRef.current);
-      pollRef.current = null;
+  const stopWatching = useCallback(() => {
+    if (unsubRef.current) {
+      unsubRef.current();
+      unsubRef.current = null;
     }
   }, []);
 
-  const pollJob = useCallback(async (jobId: string) => {
-    try {
-      const res = await financeClient.getTaxEvalJob({ jobId });
-      if (res.job) {
-        setJob(res.job);
-        if (res.job.status === 'completed' || res.job.status === 'failed') {
-          stopPolling();
+  // Subscribe to job state via Firestore. The backend mirrors every
+  // taxEvalJobStore update to taxEvalJobs/{jobId} (see backend cmd/server
+  // main.go SetTaxEvalJobPublisher), so we get push updates instead of
+  // polling getTaxEvalJob every 2s.
+  const watchJob = useCallback((jobId: string) => {
+    stopWatching();
+    if (!db) {
+      setError('Firestore not configured — cannot watch job');
+      setRunning(false);
+      return;
+    }
+    const ref = doc(db, 'taxEvalJobs', jobId);
+    unsubRef.current = onSnapshot(
+      ref,
+      (snap) => {
+        if (!snap.exists()) return;
+        const data = snap.data() as TaxEvalJob;
+        setJob(data);
+        if (data.status === 'completed' || data.status === 'failed') {
+          stopWatching();
           setRunning(false);
-          if (res.job.status === 'failed') {
-            setError(res.job.errorMessage || 'Job failed');
+          if (data.status === 'failed') {
+            setError(data.errorMessage || 'Job failed');
           }
         }
-      }
-    } catch (err: unknown) {
-      stopPolling();
-      setRunning(false);
-      setError(err instanceof Error ? err.message : 'Failed to poll job');
-    }
-  }, [stopPolling]);
+      },
+      (err) => {
+        stopWatching();
+        setRunning(false);
+        setError(err.message || 'Failed to watch job');
+      },
+    );
+  }, [stopWatching]);
 
   const startEval = useCallback(async () => {
     setError(null);
     setJob(null);
     setRunning(true);
-    stopPolling();
+    stopWatching();
 
     try {
       const res = await financeClient.runTaxEval({
@@ -421,16 +437,12 @@ export default function TaxEvalPage() {
         return;
       }
 
-      // Initial poll
-      await pollJob(jobId);
-
-      // Start polling interval
-      pollRef.current = setInterval(() => pollJob(jobId), 2000);
+      watchJob(jobId);
     } catch (err: unknown) {
       setRunning(false);
       setError(err instanceof Error ? err.message : 'Failed to start eval');
     }
-  }, [datasetPath, method, occupation, concurrency, pollJob, stopPolling]);
+  }, [datasetPath, method, occupation, concurrency, watchJob, stopWatching]);
 
   return (
     <ProFeatureGate feature="Tax Eval Dashboard">

--- a/web/src/app/components/BulkUpload.tsx
+++ b/web/src/app/components/BulkUpload.tsx
@@ -40,7 +40,8 @@ import { useFinance } from '../context/FinanceContext';
 import { useAuth } from '../context/AuthWithAdminContext';
 import { financeClient, DocumentType } from '@/lib/financeService';
 import { ExtractionMethod, ExtractionStatus } from '@/gen/pfinance/v1/types_pb';
-import type { ExtractedTransaction, StatementMetadata } from '@/gen/pfinance/v1/types_pb';
+import type { ExtractedTransaction, ExtractionJob, StatementMetadata } from '@/gen/pfinance/v1/types_pb';
+import { watchExtractionJob } from '@/lib/watchExtractionJob';
 import { ExpenseCategory } from '../types';
 import { ExpenseFrequency as ProtoExpenseFrequency } from '@/gen/pfinance/v1/types_pb';
 import { compressImage, readFileAsDataUrl, base64ToUint8Array } from '../utils/imageCompression';
@@ -641,39 +642,23 @@ export function BulkUploadDialog({ open, onOpenChange, useGemini, setUseGemini, 
   };
 
   async function pollExtractionJob(jobId: string): Promise<{ transactions: ExtractedTransaction[]; statementMetadata?: StatementMetadata } | null> {
-    // Adaptive polling: start fast (500ms), ramp up to 2s after the first few polls.
-    // Receipt extractions typically complete in 3-5s; bank statements in 8-15s.
-    const pollIntervals = [500, 500, 750, 1000, 1250, 1500, 2000]; // ms per poll index
-    const maxPollMs = 90_000;
-    const startTime = Date.now();
-    let pollIndex = 0;
-
-    while (Date.now() - startTime < maxPollMs) {
-      if (cancelledRef.current) return null;
-
-      const interval = pollIntervals[Math.min(pollIndex, pollIntervals.length - 1)];
-      await new Promise((resolve) => setTimeout(resolve, interval));
-      pollIndex++;
-
-      try {
-        const jobResp = await financeClient.getExtractionJob({ jobId });
-        if (jobResp.job?.status === ExtractionStatus.COMPLETED && jobResp.job.result) {
-          return {
-            transactions: jobResp.job.result.transactions,
-            statementMetadata: jobResp.job.result.statementMetadata,
-          };
-        }
-        if (jobResp.job?.status === ExtractionStatus.FAILED) {
-          throw new Error(jobResp.job.errorMessage || 'Extraction failed');
-        }
-      } catch (pollErr) {
-        if (pollErr instanceof Error && (pollErr.message.includes('Extraction failed') || pollErr.message.includes('failed'))) {
-          throw pollErr;
-        }
-        console.error('Poll error:', pollErr);
-      }
+    // Push-based: subscribe to extractionJobs/{jobId} via Firestore. Backend
+    // mirrors every JobStore update there (see backend cmd/server/main.go
+    // SetJobPublisher) so we get the result the moment it's written. No
+    // polling, no kept-warm Cloud Run instances.
+    try {
+      const job = await watchExtractionJob(jobId, {
+        isCancelled: () => cancelledRef.current,
+      });
+      if (!job.result) return null;
+      return {
+        transactions: job.result.transactions,
+        statementMetadata: job.result.statementMetadata,
+      };
+    } catch (err) {
+      if (err instanceof Error && err.message === 'cancelled') return null;
+      throw err;
     }
-    throw new Error('Extraction timed out');
   }
 
   function updateFileStatus(id: string, status: BulkFile['status'], error?: string) {

--- a/web/src/app/components/SmartExpenseEntry.tsx
+++ b/web/src/app/components/SmartExpenseEntry.tsx
@@ -31,6 +31,7 @@ import { checkForDuplicates, type DuplicateMatch } from '@/lib/checkDuplicates';
 import { ExpenseCategory, ExpenseFrequency } from '../types';
 import { financeClient, DocumentType } from '@/lib/financeService';
 import { ExtractionMethod, ExtractionStatus } from '@/gen/pfinance/v1/types_pb';
+import { watchExtractionJob } from '@/lib/watchExtractionJob';
 import type { FieldConfidence } from '@/gen/pfinance/v1/types_pb';
 import { ConfidenceBadge } from '@/components/ui/confidence-badge';
 import { FieldConfidenceDetail } from './FieldConfidenceDetail';
@@ -657,28 +658,13 @@ export default function SmartExpenseEntry() {
 
         // Handle async processing (multi-page PDF)
         if (response.status === ExtractionStatus.PROCESSING && response.jobId) {
-          // Poll for completion
-          const pollJob = async () => {
-            const maxPolls = 60; // 1.5s * 60 = 90s max
-            for (let i = 0; i < maxPolls; i++) {
-              await new Promise(resolve => setTimeout(resolve, 1500));
-              try {
-                const jobResp = await financeClient.getExtractionJob({ jobId: response.jobId });
-                if (jobResp.job?.status === ExtractionStatus.COMPLETED && jobResp.job.result) {
-                  return jobResp.job.result;
-                }
-                if (jobResp.job?.status === ExtractionStatus.FAILED) {
-                  throw new Error(jobResp.job.errorMessage || 'Extraction failed');
-                }
-              } catch (pollErr) {
-                console.error('Poll error:', pollErr);
-              }
-            }
-            throw new Error('Extraction timed out');
-          };
-
+          // Push-based via Firestore listener (was 1.5s polling).
           try {
-            const asyncResult = await pollJob();
+            const job = await watchExtractionJob(response.jobId);
+            if (!job.result) {
+              throw new Error('Extraction completed without result');
+            }
+            const asyncResult = job.result;
             if (asyncResult.transactions.length > 0) {
               const tx = asyncResult.transactions[0];
               const categoryName = mapProtoCategory(tx.suggestedCategory);

--- a/web/src/lib/watchExtractionJob.ts
+++ b/web/src/lib/watchExtractionJob.ts
@@ -1,0 +1,89 @@
+/**
+ * watchExtractionJob — promise wrapper around a Firestore onSnapshot listener
+ * for an extraction job document.
+ *
+ * Replaces the per-component setInterval polling that hammered
+ * `getExtractionJob` every 500ms–2s during PDF/receipt processing. The
+ * backend mirrors every JobStore Create/Update to `extractionJobs/{jobId}`
+ * (see backend cmd/server/main.go SetJobPublisher), so we listen there
+ * instead. Resolves when the job hits COMPLETED, rejects on FAILED or
+ * timeout, and unsubscribes in every terminal path including caller cancel.
+ */
+
+import { doc, onSnapshot } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+import { ExtractionStatus, type ExtractionJob } from '@/gen/pfinance/v1/types_pb';
+
+export interface WatchExtractionJobOptions {
+  /** Reject after this many ms if the job hasn't completed. Default 90s. */
+  timeoutMs?: number;
+  /** Polling-cancel signal — caller flips this to abort. */
+  isCancelled?: () => boolean;
+}
+
+/**
+ * Watches an extraction job until it's COMPLETED, FAILED, or timed out.
+ * Returns the final ExtractionJob proto (matching the GetExtractionJob RPC
+ * response shape) on success.
+ *
+ * Note: Firestore documents store proto fields with PascalCase keys (the
+ * backend writes the proto directly via `.Set(ctx, job)`), so the snapshot
+ * data shape mirrors the proto JSON. Cast through unknown to ExtractionJob
+ * — runtime shape matches because backend writes the same proto type.
+ */
+export function watchExtractionJob(
+  jobId: string,
+  opts: WatchExtractionJobOptions = {},
+): Promise<ExtractionJob> {
+  const { timeoutMs = 90_000, isCancelled } = opts;
+
+  return new Promise((resolve, reject) => {
+    if (!db) {
+      reject(new Error('Firestore not configured'));
+      return;
+    }
+
+    let unsub: (() => void) | null = null;
+    let cancelInterval: ReturnType<typeof setInterval> | null = null;
+
+    const cleanup = () => {
+      if (unsub) { unsub(); unsub = null; }
+      if (timer) { clearTimeout(timer); }
+      if (cancelInterval) { clearInterval(cancelInterval); cancelInterval = null; }
+    };
+
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('Extraction timed out'));
+    }, timeoutMs);
+
+    // Cancel-poll: caller can flip a ref to abort. Cheap (no backend traffic).
+    if (isCancelled) {
+      cancelInterval = setInterval(() => {
+        if (isCancelled()) {
+          cleanup();
+          reject(new Error('cancelled'));
+        }
+      }, 250);
+    }
+
+    unsub = onSnapshot(
+      doc(db, 'extractionJobs', jobId),
+      (snap) => {
+        if (!snap.exists()) return;
+        const job = snap.data() as unknown as ExtractionJob;
+        if (job.status === ExtractionStatus.COMPLETED && job.result) {
+          cleanup();
+          resolve(job);
+        } else if (job.status === ExtractionStatus.FAILED) {
+          cleanup();
+          reject(new Error(job.errorMessage || 'Extraction failed'));
+        }
+      },
+      (err) => {
+        cleanup();
+        reject(err);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Follow-up to #28 — eliminates the last 3 background polling loops in the web frontend.

| Site | Was | Now |
|---|---|---|
| BulkUpload | adaptive setInterval 500ms→2s for ~90s | onSnapshot(extractionJobs/{jobId}) |
| SmartExpenseEntry | setInterval 1.5s for ~90s | onSnapshot(extractionJobs/{jobId}) |
| tax/eval/page | setInterval 2s for job duration | onSnapshot(taxEvalJobs/{jobId}) |

## Backend

Dual-write pattern: in-memory job stores remain the source of truth for the existing GetExtractionJob / GetTaxEvalJob RPCs (unchanged behaviour). Job state is *also* mirrored to Firestore so the frontend can listen via onSnapshot.

- \`extraction.JobStore\` gets an optional \`JobPublisher\` hook fired on Create/Update.
- \`ExtractionService.SetJobPublisher\` wires it.
- \`taxEvalJobStore\` follows the same pattern via \`SetTaxEvalJobPublisher\`.
- \`cmd/server/main.go\` wires both publishers to write \`extractionJobs/{id}\` and \`taxEvalJobs/{id}\` documents. Skipped in memory-store mode where there is no Firestore.

## Frontend

New helper \`web/src/lib/watchExtractionJob.ts\` wraps \`onSnapshot\` in a promise that resolves on \`COMPLETED\`, rejects on \`FAILED\` or timeout. Supports cancel via \`isCancelled\` callback so existing cancel paths still work.

## Test plan
- [x] \`go test ./internal/extraction/... ./internal/service/...\` — 746 pass
- [x] \`tsc --noEmit\` — clean
- [ ] After deploy: upload a multi-page PDF in BulkUpload, confirm UI shows extracted transactions without polling \`/getExtractionJob\` (check network tab)
- [ ] After deploy: trigger a tax eval, confirm progress updates push in real-time
- [ ] After deploy: confirm pfinance-backend Cloud Run instance count drops to 0 within 15 min of last user action (was perpetually 1 even after 90s job ended due to keep-warm cascade)