### PR TITLE
[codex] Fix analytics views

### DIFF
--- a/web/e2e/analytics.spec.ts
+++ b/web/e2e/analytics.spec.ts
@@ -1,0 +1,163 @@
+import { expect, test, type Route } from '@playwright/test';
+
+async function fulfillConnect(route: Route, body: Record<string, unknown>) {
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    headers: {
+      'connect-protocol-version': '1',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+test.describe('Advanced Analytics', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      const fixedNow = new Date('2026-05-05T12:00:00.000Z').getTime();
+      const RealDate = Date;
+
+      class FixedDate extends RealDate {
+        constructor(...args: any[]) {
+          if (args.length === 0) {
+            super(fixedNow);
+          } else {
+            super(...args);
+          }
+        }
+
+        static now() {
+          return fixedNow;
+        }
+      }
+
+      window.Date = FixedDate as DateConstructor;
+    });
+
+    await page.route('**/pfinance.v1.FinanceService/GetDailyAggregates', async (route) => {
+      await fulfillConnect(route, {
+        aggregates: [
+          {
+            date: '2026-05-01',
+            totalAmount: 42,
+            transactionCount: 1,
+            categoryAmounts: [{ category: 1, amount: 42, count: 1 }],
+          },
+          {
+            date: '2026-05-03',
+            totalAmount: 18,
+            transactionCount: 2,
+            categoryAmounts: [{ category: 3, amount: 18, count: 2 }],
+          },
+        ],
+        maxDailyAmount: 42,
+      });
+    });
+
+    await page.route('**/pfinance.v1.FinanceService/GetSpendingTrends', async (route) => {
+      await fulfillConnect(route, {
+        expenseSeries: [
+          { date: '2026-04-20', value: 100, label: 'Apr 20' },
+          { date: '2026-04-27', value: 140, label: 'Apr 27' },
+          { date: '2026-05-04', value: 90, label: 'May 04' },
+        ],
+        incomeSeries: [
+          { date: '2026-04-20', value: 500, label: 'Apr 20' },
+          { date: '2026-04-27', value: 500, label: 'Apr 27' },
+          { date: '2026-05-04', value: 500, label: 'May 04' },
+        ],
+        trendSlope: -5,
+        trendRSquared: 0.73,
+      });
+    });
+
+    await page.route('**/pfinance.v1.FinanceService/GetCategoryComparison', async (route) => {
+      await fulfillConnect(route, {
+        categories: [
+          { category: 1, currentAmount: 240, previousAmount: 180, changePercent: 33.3 },
+          { category: 3, currentAmount: 90, previousAmount: 120, changePercent: -25 },
+          { category: 7, currentAmount: 75, previousAmount: 50, changePercent: 50 },
+        ],
+      });
+    });
+
+    await page.route('**/pfinance.v1.FinanceService/DetectAnomalies', async (route) => {
+      await fulfillConnect(route, {
+        anomalies: [],
+        totalAnomalies: 0,
+        anomalousSpendTotal: 0,
+        topAnomalyCategory: '',
+      });
+    });
+
+    await page.route('**/pfinance.v1.FinanceService/GetCashFlowForecast', async (route) => {
+      await fulfillConnect(route, {
+        incomeForecast: [
+          { date: '2026-05-05', predicted: 120 },
+          { date: '2026-05-06', predicted: 120 },
+        ],
+        expenseForecast: [
+          { date: '2026-05-05', predicted: 40, lowerBound: 20, upperBound: 80 },
+          { date: '2026-05-06', predicted: 50, lowerBound: 25, upperBound: 90 },
+        ],
+        netForecast: [
+          { date: '2026-05-05', predicted: 80 },
+          { date: '2026-05-06', predicted: 70 },
+        ],
+      });
+    });
+
+    await page.route('**/pfinance.v1.FinanceService/GetWaterfallData', async (route) => {
+      await fulfillConnect(route, {
+        entries: [
+          { label: 'Gross Income', amount: 5000, entryType: 1, runningTotal: 5000 },
+          { label: 'Tax', amount: 1000, entryType: 3, runningTotal: 4000 },
+          { label: 'Food', amount: 800, entryType: 2, runningTotal: 3200 },
+          { label: 'Net Savings', amount: 3200, entryType: 4, runningTotal: 3200 },
+        ],
+        periodLabel: 'May 2026',
+      });
+    });
+
+    await page.route('**/pfinance.v1.FinanceService/GetExtractionMetrics', async (route) => {
+      await fulfillConnect(route, {
+        totalExtractions: 2,
+        totalTransactions: 12,
+        totalCorrections: 1,
+        correctionRate: 0.08,
+        averageConfidence: 0.91,
+        correctionsByField: { amount: 1 },
+        correctionsByCategory: { food: 1 },
+        recentEvents: [],
+      });
+    });
+  });
+
+  test('renders every analytics tab with populated chart data', async ({ page }) => {
+    await page.goto('/personal/analytics');
+
+    await expect(page.getByText('Spending Heatmap')).toBeVisible();
+    await expect(page.getByRole('tabpanel', { name: 'Heatmap' }).getByText('May').first()).toBeVisible();
+
+    await page.getByRole('tab', { name: 'Trends' }).click();
+    await expect(page.getByText('Spending Trends')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Category Spend Over Time' })).toBeVisible();
+    await expect(page.getByRole('combobox', { name: 'Category trend category' })).toBeVisible();
+
+    await page.getByRole('tab', { name: 'Categories' }).click();
+    await expect(page.getByText('Category Comparison')).toBeVisible();
+
+    await page.getByRole('tab', { name: 'Anomalies' }).click();
+    await expect(page.getByText('No anomalies detected. Your spending looks normal!')).toBeVisible();
+
+    await page.getByRole('tab', { name: 'Forecast' }).click();
+    await expect(page.getByText('Cash Flow Forecast')).toBeVisible();
+
+    await page.getByRole('tab', { name: 'Flow' }).click();
+    await expect(page.getByText('Money Flow')).toBeVisible();
+
+    await page.getByRole('tab', { name: 'Extraction' }).click();
+    await expect(page.getByText('Extraction Quality')).toBeVisible();
+    await expect(page.getByText('91.0%')).toBeVisible();
+  });
+});

--- a/web/src/app/(app)/personal/analytics/__tests__/AnalyticsPage.test.tsx
+++ b/web/src/app/(app)/personal/analytics/__tests__/AnalyticsPage.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AnalyticsPage from '../page';
+
+jest.mock('../../../../components/ProFeatureGate', () => ({
+  ProFeatureGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  UpgradePrompt: ({ feature }: { feature: string }) => <div>{feature} requires Pro</div>,
+}));
+
+jest.mock('../../../../context/FinanceContext', () => ({
+  useFinance: () => ({ expenses: [] }),
+}));
+
+jest.mock('../../../../components/charts', () => ({
+  LazySpendingHeatmap: () => <div data-testid="heatmap-chart" />,
+  LazySpendingTrendChart: () => <div data-testid="trend-chart" />,
+  LazyCategoryRadarChart: () => <div data-testid="radar-chart" />,
+  LazyAnomalyScatterPlot: () => <div data-testid="anomaly-chart" />,
+  LazyCashFlowForecast: () => <div data-testid="forecast-chart" />,
+  LazyWaterfallChart: () => <div data-testid="waterfall-chart" />,
+}));
+
+jest.mock('../../../../metrics/hooks/useAnalyticsData', () => ({
+  useHeatmapData: () => ({
+    data: { days: [], maxValue: 0 },
+    loading: false,
+    error: null,
+  }),
+  useSpendingTrends: () => ({
+    expenseSeries: [{ date: '2026-05-01', value: 42, valueCents: BigInt(4200), label: 'May 1' }],
+    incomeSeries: [],
+    trendSlope: 0,
+    trendRSquared: 1,
+    loading: false,
+    error: null,
+  }),
+  useCategoryComparison: () => ({
+    data: [],
+    loading: false,
+    error: null,
+  }),
+  useAnomalies: () => ({
+    data: [],
+    totalAnomalousSpend: 0,
+    loading: false,
+    error: null,
+  }),
+  useCashFlowForecast: () => ({
+    incomeForecast: [],
+    expenseForecast: [],
+    netForecast: [],
+    loading: false,
+    error: null,
+  }),
+  useWaterfallData: () => ({
+    data: [],
+    loading: false,
+    error: null,
+  }),
+}));
+
+jest.mock('../../../../metrics/hooks/useExtractionMetrics', () => ({
+  useExtractionMetrics: () => ({
+    data: {
+      totalExtractions: 0,
+      totalTransactions: 0,
+      averageConfidence: 0,
+      correctionRate: 0,
+      correctionsByField: {},
+      correctionsByCategory: {},
+      recentEvents: [],
+    },
+    loading: false,
+    error: null,
+  }),
+}));
+
+describe('AnalyticsPage', () => {
+  it('includes a dedicated category spend over time view', async () => {
+    const user = userEvent.setup();
+    render(<AnalyticsPage />);
+
+    await user.click(screen.getByRole('tab', { name: 'Trends' }));
+
+    expect(
+      screen.getByRole('heading', { name: 'Category Spend Over Time' })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/app/(app)/personal/analytics/page.tsx
+++ b/web/src/app/(app)/personal/analytics/page.tsx
@@ -30,6 +30,21 @@ import { UpgradePrompt } from '../../../components/ProFeatureGate';
 import { AlertCircle, FileSearch } from 'lucide-react';
 import { useFinance } from '../../../context/FinanceContext';
 
+const expenseCategories = [
+  'Food',
+  'Housing',
+  'Transportation',
+  'Entertainment',
+  'Healthcare',
+  'Utilities',
+  'Shopping',
+  'Education',
+  'Travel',
+  'Other',
+] as const;
+
+type ExpenseCategoryName = (typeof expenseCategories)[number];
+
 function isSubscriptionError(message: string): boolean {
   const lower = message.toLowerCase();
   return lower.includes('pro subscription') ||
@@ -52,6 +67,16 @@ function ErrorBanner({ message }: { message: string }) {
 
 function LoadingSkeleton() {
   return <Skeleton className="h-[400px] w-full" />;
+}
+
+function toTrendChartData(
+  series: Array<{ date: string; value: number; valueCents: bigint; label: string }>
+) {
+  return series.map((pt) => ({
+    date: pt.date,
+    value: pt.valueCents !== BigInt(0) ? Number(pt.valueCents) / 100 : pt.value,
+    label: pt.label,
+  }));
 }
 
 // ============================================================================
@@ -121,80 +146,117 @@ function HeatmapTab() {
 function TrendsTab() {
   const [granularity, setGranularity] = useState<'day' | 'week' | 'month'>('week');
   const [periods, setPeriods] = useState(12);
+  const [category, setCategory] = useState<ExpenseCategoryName>('Food');
 
   const { expenseSeries, incomeSeries, trendSlope, trendRSquared, loading, error } =
     useSpendingTrends(granularity, periods);
+  const {
+    expenseSeries: categoryExpenseSeries,
+    trendSlope: categoryTrendSlope,
+    trendRSquared: categoryTrendRSquared,
+    loading: categoryLoading,
+    error: categoryError,
+  } = useSpendingTrends(granularity, periods, category);
 
-  const chartData = useMemo(
-    () =>
-      expenseSeries.map((pt) => ({
-        date: pt.date,
-        value: pt.valueCents !== BigInt(0) ? Number(pt.valueCents) / 100 : pt.value,
-        label: pt.label,
-      })),
-    [expenseSeries]
-  );
+  const chartData = useMemo(() => toTrendChartData(expenseSeries), [expenseSeries]);
 
-  const incomeData = useMemo(
-    () =>
-      incomeSeries.map((pt) => ({
-        date: pt.date,
-        value: pt.valueCents !== BigInt(0) ? Number(pt.valueCents) / 100 : pt.value,
-        label: pt.label,
-      })),
-    [incomeSeries]
+  const incomeData = useMemo(() => toTrendChartData(incomeSeries), [incomeSeries]);
+  const categoryChartData = useMemo(
+    () => toTrendChartData(categoryExpenseSeries),
+    [categoryExpenseSeries]
   );
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between space-y-0">
-        <div>
-          <CardTitle>Spending Trends</CardTitle>
-          <CardDescription>Track spending patterns over time</CardDescription>
-        </div>
-        <div className="flex items-center gap-2">
-          <Select value={granularity} onValueChange={(v) => setGranularity(v as typeof granularity)}>
-            <SelectTrigger className="w-24">
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <div>
+            <CardTitle>Spending Trends</CardTitle>
+            <CardDescription>Track spending patterns over time</CardDescription>
+          </div>
+          <div className="flex items-center gap-2">
+            <Select value={granularity} onValueChange={(v) => setGranularity(v as typeof granularity)}>
+              <SelectTrigger className="w-24" aria-label="Trend granularity">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="day">Daily</SelectItem>
+                <SelectItem value="week">Weekly</SelectItem>
+                <SelectItem value="month">Monthly</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={String(periods)} onValueChange={(v) => setPeriods(Number(v))}>
+              <SelectTrigger className="w-24" aria-label="Trend period count">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="6">6 periods</SelectItem>
+                <SelectItem value="12">12 periods</SelectItem>
+                <SelectItem value="24">24 periods</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {error && <ErrorBanner message={error} />}
+          {loading && <LoadingSkeleton />}
+          {!loading && !error && chartData.length > 0 && (
+            <div className="h-[400px]">
+              <LazySpendingTrendChart
+                expenseSeries={chartData}
+                incomeSeries={incomeData}
+                trendSlope={trendSlope}
+                trendRSquared={trendRSquared}
+              />
+            </div>
+          )}
+          {!loading && !error && chartData.length === 0 && (
+            <div className="h-[400px] flex items-center justify-center text-muted-foreground text-sm">
+              No trend data available.
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <div>
+            <CardTitle role="heading" aria-level={3}>Category Spend Over Time</CardTitle>
+            <CardDescription>Isolate one category across the same period range</CardDescription>
+          </div>
+          <Select value={category} onValueChange={(v) => setCategory(v as ExpenseCategoryName)}>
+            <SelectTrigger className="w-40" aria-label="Category trend category">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="day">Daily</SelectItem>
-              <SelectItem value="week">Weekly</SelectItem>
-              <SelectItem value="month">Monthly</SelectItem>
+              {expenseCategories.map((cat) => (
+                <SelectItem key={cat} value={cat}>
+                  {cat}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
-          <Select value={String(periods)} onValueChange={(v) => setPeriods(Number(v))}>
-            <SelectTrigger className="w-24">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="6">6 periods</SelectItem>
-              <SelectItem value="12">12 periods</SelectItem>
-              <SelectItem value="24">24 periods</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-      </CardHeader>
-      <CardContent>
-        {error && <ErrorBanner message={error} />}
-        {loading && <LoadingSkeleton />}
-        {!loading && !error && chartData.length > 0 && (
-          <div className="h-[400px]">
-            <LazySpendingTrendChart
-              expenseSeries={chartData}
-              incomeSeries={incomeData}
-              trendSlope={trendSlope}
-              trendRSquared={trendRSquared}
-            />
-          </div>
-        )}
-        {!loading && !error && chartData.length === 0 && (
-          <div className="h-[400px] flex items-center justify-center text-muted-foreground text-sm">
-            No trend data available.
-          </div>
-        )}
-      </CardContent>
-    </Card>
+        </CardHeader>
+        <CardContent>
+          {categoryError && <ErrorBanner message={categoryError} />}
+          {categoryLoading && <LoadingSkeleton />}
+          {!categoryLoading && !categoryError && categoryChartData.length > 0 && (
+            <div className="h-[320px]">
+              <LazySpendingTrendChart
+                expenseSeries={categoryChartData}
+                trendSlope={categoryTrendSlope}
+                trendRSquared={categoryTrendRSquared}
+              />
+            </div>
+          )}
+          {!categoryLoading && !categoryError && categoryChartData.length === 0 && (
+            <div className="h-[320px] flex items-center justify-center text-muted-foreground text-sm">
+              No category trend data available.
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }
 

--- a/web/src/app/components/charts/SpendingHeatmap.tsx
+++ b/web/src/app/components/charts/SpendingHeatmap.tsx
@@ -65,6 +65,11 @@ function toDateKey(date: Date): string {
   return `${y}-${m}-${d}`;
 }
 
+function dateFromKey(dateStr: string): Date {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
 /**
  * Transform flat HeatmapDay[] into weekly bin data for HeatmapRect.
  * Each "bin" is a week column, containing up to 7 day entries.
@@ -76,9 +81,12 @@ function transformToBinData(days: HeatmapDay[]): HeatmapBinData[] {
   const sorted = [...days].sort((a, b) => a.date.localeCompare(b.date));
 
   // Determine the start of the first week (Sunday)
-  const firstDate = new Date(sorted[0].date);
+  const firstDate = dateFromKey(sorted[0].date);
+  const lastDate = dateFromKey(sorted[sorted.length - 1].date);
   const startOfWeek = new Date(firstDate);
   startOfWeek.setDate(startOfWeek.getDate() - startOfWeek.getDay());
+  const endOfWeek = new Date(lastDate);
+  endOfWeek.setDate(endOfWeek.getDate() + (6 - endOfWeek.getDay()));
 
   // Build a map for quick lookup
   const dayMap = new Map<string, HeatmapDay>();
@@ -86,14 +94,14 @@ function transformToBinData(days: HeatmapDay[]): HeatmapBinData[] {
     dayMap.set(d.date, d);
   }
 
-  // Build 52 weeks of bins
   const bins: HeatmapBinData[] = [];
   const current = new Date(startOfWeek);
+  let week = 0;
 
-  for (let week = 0; week < 53; week++) {
+  while (current <= endOfWeek) {
     const weekBins: HeatmapBin[] = [];
     for (let day = 0; day < 7; day++) {
-      const dateStr = current.toISOString().split('T')[0];
+      const dateStr = toDateKey(current);
       const entry = dayMap.get(dateStr);
       weekBins.push({
         bin: day,
@@ -105,6 +113,7 @@ function transformToBinData(days: HeatmapDay[]): HeatmapBinData[] {
       current.setDate(current.getDate() + 1);
     }
     bins.push({ bin: week, bins: weekBins });
+    week++;
   }
 
   return bins;

--- a/web/src/app/components/charts/SpendingTrendChart.tsx
+++ b/web/src/app/components/charts/SpendingTrendChart.tsx
@@ -154,9 +154,8 @@ function TrendChart({
     const firstDate = parsedExpenses[0].date.getTime();
     const lastDate = parsedExpenses[parsedExpenses.length - 1].date.getTime();
     const firstValue = parsedExpenses[0].value;
-    // Simple linear: y = firstValue + slope * (daysDiff)
-    const daysDiff = (lastDate - firstDate) / (1000 * 60 * 60 * 24);
-    const lastValue = firstValue + trendSlope * daysDiff;
+    const periodDiff = parsedExpenses.length - 1;
+    const lastValue = firstValue + trendSlope * periodDiff;
     return [
       { date: parsedExpenses[0].date, value: firstValue },
       { date: parsedExpenses[parsedExpenses.length - 1].date, value: lastValue },

--- a/web/src/app/metrics/hooks/__tests__/useAnalyticsData.test.ts
+++ b/web/src/app/metrics/hooks/__tests__/useAnalyticsData.test.ts
@@ -1,0 +1,84 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useHeatmapData } from '../useAnalyticsData';
+import { ExpenseCategory } from '@/gen/pfinance/v1/types_pb';
+import { financeClient } from '@/lib/financeService';
+
+jest.mock('@/lib/financeService', () => ({
+  financeClient: {
+    getDailyAggregates: jest.fn(),
+  },
+}));
+
+describe('useHeatmapData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fills every day in the requested range so the heatmap grid is complete', async () => {
+    (financeClient.getDailyAggregates as jest.Mock).mockResolvedValue({
+      aggregates: [
+        {
+          date: '2026-05-01',
+          totalAmount: 42,
+          totalAmountCents: BigInt(4200),
+          transactionCount: 1,
+          categoryAmounts: [
+            {
+              category: ExpenseCategory.FOOD,
+              amount: 42,
+              amountCents: BigInt(4200),
+              count: 1,
+            },
+          ],
+        },
+        {
+          date: '2026-05-03',
+          totalAmount: 18,
+          totalAmountCents: BigInt(1800),
+          transactionCount: 2,
+          categoryAmounts: [
+            {
+              category: ExpenseCategory.TRANSPORTATION,
+              amount: 18,
+              amountCents: BigInt(1800),
+              count: 2,
+            },
+          ],
+        },
+      ],
+      maxDailyAmount: 42,
+      maxDailyAmountCents: BigInt(4200),
+    });
+
+    const { result } = renderHook(() =>
+      useHeatmapData(
+        new Date('2026-05-01T00:00:00.000Z'),
+        new Date('2026-05-03T00:00:00.000Z')
+      )
+    );
+
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+
+    expect(result.current.data?.days).toEqual([
+      {
+        date: '2026-05-01',
+        value: 42,
+        count: 1,
+        categories: [{ category: 'Food', amount: 42, count: 1 }],
+      },
+      {
+        date: '2026-05-02',
+        value: 0,
+        count: 0,
+        categories: [],
+      },
+      {
+        date: '2026-05-03',
+        value: 18,
+        count: 2,
+        categories: [{ category: 'Transportation', amount: 18, count: 2 }],
+      },
+    ]);
+    expect(result.current.data?.maxValue).toBe(42);
+  });
+});

--- a/web/src/app/metrics/hooks/useAnalyticsData.ts
+++ b/web/src/app/metrics/hooks/useAnalyticsData.ts
@@ -43,6 +43,30 @@ function timestampFromDate(date: Date): Timestamp {
   });
 }
 
+function localDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function dateKeysInRange(startDate: Date, endDate: Date): string[] {
+  const start = startOfLocalDay(startDate);
+  const end = startOfLocalDay(endDate);
+
+  if (start > end) return [];
+
+  const keys: string[] = [];
+  for (const cursor = new Date(start); cursor <= end; cursor.setDate(cursor.getDate() + 1)) {
+    keys.push(localDateKey(cursor));
+  }
+  return keys;
+}
+
 /**
  * Convert an ExpenseCategory enum value to a human-readable string.
  * e.g. ExpenseCategory.FOOD (whose key is "FOOD") -> "Food"
@@ -197,8 +221,9 @@ export function useHeatmapData(startDate: Date, endDate: Date) {
         endDate: timestampFromDate(endDate),
       });
 
-      const days: HeatmapDay[] = response.aggregates.map(
-        (agg: DailyAggregate) => ({
+      const aggregateByDate = new Map<string, HeatmapDay>();
+      for (const agg of response.aggregates as DailyAggregate[]) {
+        aggregateByDate.set(agg.date, {
           date: agg.date,
           value: centsOrFallback(agg.totalAmountCents, agg.totalAmount),
           count: agg.transactionCount,
@@ -207,7 +232,17 @@ export function useHeatmapData(startDate: Date, endDate: Date) {
             amount: centsOrFallback(ca.amountCents, ca.amount),
             count: ca.count,
           })),
-        })
+        });
+      }
+
+      const days: HeatmapDay[] = dateKeysInRange(startDate, endDate).map(
+        (date) =>
+          aggregateByDate.get(date) ?? {
+            date,
+            value: 0,
+            count: 0,
+            categories: [],
+          }
       );
 
       const maxValue =


### PR DESCRIPTION
## Summary

Fixes the advanced analytics views so the spending heatmap and trends surface behave as expected.

- Fill every day in the requested heatmap range, including zero-spend days, so the calendar grid is complete.
- Render the heatmap over the actual requested range instead of a fixed 53-week span from the first returned expense.
- Add a dedicated category spend-over-time chart with a category selector.
- Correct the trend-line projection to use period index spacing.
- Add focused Jest tests and a Chromium Playwright smoke test covering all analytics tabs.

## Validation

- `npm test -- --runTestsByPath 'src/app/metrics/hooks/__tests__/useAnalyticsData.test.ts' 'src/app/(app)/personal/analytics/__tests__/AnalyticsPage.test.tsx' --runInBand`
- `npm run type-check`
- `go test ./internal/service -run 'TestAnalytics' -count=1`
- `NEXT_PUBLIC_DEV_MODE=true npx playwright test e2e/analytics.spec.ts --project=chromium`