### PR TITLE
Fix analytics category history fallback

### DIFF
--- a/backend/internal/service/analytics_service.go
+++ b/backend/internal/service/analytics_service.go
@@ -40,6 +40,116 @@ func effectiveDollars(amountCents int64, amountDollars float64) float64 {
 	return amountDollars
 }
 
+type analyticsPeriodInfo struct {
+	start time.Time
+	end   time.Time
+	label string
+}
+
+func buildTrendPeriods(anchor time.Time, granularity pfinancev1.Granularity, periods int32) []analyticsPeriodInfo {
+	periodInfos := make([]analyticsPeriodInfo, periods)
+	for i := int32(0); i < periods; i++ {
+		offset := periods - 1 - i
+		var ps, pe time.Time
+		var label string
+		switch granularity {
+		case pfinancev1.Granularity_GRANULARITY_DAY:
+			ps = time.Date(anchor.Year(), anchor.Month(), anchor.Day(), 0, 0, 0, 0, anchor.Location()).AddDate(0, 0, -int(offset))
+			pe = ps.Add(24*time.Hour - time.Second)
+			label = ps.Format("2006-01-02")
+		case pfinancev1.Granularity_GRANULARITY_WEEK:
+			weekStart := time.Date(anchor.Year(), anchor.Month(), anchor.Day(), 0, 0, 0, 0, anchor.Location())
+			weekStart = weekStart.AddDate(0, 0, -int(weekStart.Weekday()))
+			ps = weekStart.AddDate(0, 0, -int(offset)*7)
+			pe = ps.AddDate(0, 0, 6)
+			pe = time.Date(pe.Year(), pe.Month(), pe.Day(), 23, 59, 59, 0, pe.Location())
+			label = ps.Format("Jan 02")
+		default:
+			ps = time.Date(anchor.Year(), anchor.Month(), 1, 0, 0, 0, 0, anchor.Location()).AddDate(0, -int(offset), 0)
+			pe = ps.AddDate(0, 1, -1)
+			pe = time.Date(pe.Year(), pe.Month(), pe.Day(), 23, 59, 59, 0, pe.Location())
+			label = ps.Format("Jan 2006")
+		}
+		periodInfos[i] = analyticsPeriodInfo{start: ps, end: pe, label: label}
+	}
+	return periodInfos
+}
+
+func categoryComparisonBounds(anchor time.Time, period string) (currentStart, currentEnd, prevStart, prevEnd time.Time) {
+	switch period {
+	case "week":
+		daysFromSunday := int(anchor.Weekday())
+		currentStart = time.Date(anchor.Year(), anchor.Month(), anchor.Day(), 0, 0, 0, 0, anchor.Location()).AddDate(0, 0, -daysFromSunday)
+		currentEnd = currentStart.AddDate(0, 0, 6)
+		currentEnd = time.Date(currentEnd.Year(), currentEnd.Month(), currentEnd.Day(), 23, 59, 59, 0, currentEnd.Location())
+		prevStart = currentStart.AddDate(0, 0, -7)
+		prevEnd = currentStart.AddDate(0, 0, -1)
+		prevEnd = time.Date(prevEnd.Year(), prevEnd.Month(), prevEnd.Day(), 23, 59, 59, 0, prevEnd.Location())
+	case "quarter":
+		month := anchor.Month()
+		quarterStartMonth := time.Month(((int(month)-1)/3)*3 + 1)
+		currentStart = time.Date(anchor.Year(), quarterStartMonth, 1, 0, 0, 0, 0, anchor.Location())
+		currentEnd = currentStart.AddDate(0, 3, -1)
+		currentEnd = time.Date(currentEnd.Year(), currentEnd.Month(), currentEnd.Day(), 23, 59, 59, 0, currentEnd.Location())
+		prevStart = currentStart.AddDate(0, -3, 0)
+		prevEnd = currentStart.AddDate(0, 0, -1)
+		prevEnd = time.Date(prevEnd.Year(), prevEnd.Month(), prevEnd.Day(), 23, 59, 59, 0, prevEnd.Location())
+	case "year":
+		currentStart = time.Date(anchor.Year(), time.January, 1, 0, 0, 0, 0, anchor.Location())
+		currentEnd = time.Date(anchor.Year(), time.December, 31, 23, 59, 59, 0, anchor.Location())
+		prevStart = time.Date(anchor.Year()-1, time.January, 1, 0, 0, 0, 0, anchor.Location())
+		prevEnd = time.Date(anchor.Year()-1, time.December, 31, 23, 59, 59, 0, anchor.Location())
+	default: // "month"
+		currentStart = time.Date(anchor.Year(), anchor.Month(), 1, 0, 0, 0, 0, anchor.Location())
+		currentEnd = currentStart.AddDate(0, 1, -1)
+		currentEnd = time.Date(currentEnd.Year(), currentEnd.Month(), currentEnd.Day(), 23, 59, 59, 0, currentEnd.Location())
+		prevStart = currentStart.AddDate(0, -1, 0)
+		prevEnd = currentStart.AddDate(0, 0, -1)
+		prevEnd = time.Date(prevEnd.Year(), prevEnd.Month(), prevEnd.Day(), 23, 59, 59, 0, prevEnd.Location())
+	}
+	return currentStart, currentEnd, prevStart, prevEnd
+}
+
+func latestExpenseDate(expenses []*pfinancev1.Expense, category pfinancev1.ExpenseCategory) (time.Time, bool) {
+	var latest time.Time
+	found := false
+	for _, expense := range expenses {
+		if expense.Date == nil {
+			continue
+		}
+		if category != pfinancev1.ExpenseCategory_EXPENSE_CATEGORY_UNSPECIFIED && expense.Category != category {
+			continue
+		}
+		date := expense.Date.AsTime()
+		if !found || date.After(latest) {
+			latest = date
+			found = true
+		}
+	}
+	return latest, found
+}
+
+func latestIncomeDate(incomes []*pfinancev1.Income) (time.Time, bool) {
+	var latest time.Time
+	found := false
+	for _, income := range incomes {
+		if income.Date == nil {
+			continue
+		}
+		date := income.Date.AsTime()
+		if !found || date.After(latest) {
+			latest = date
+			found = true
+		}
+	}
+	return latest, found
+}
+
+func hasExpenseForCategory(expenses []*pfinancev1.Expense, category pfinancev1.ExpenseCategory) bool {
+	_, ok := latestExpenseDate(expenses, category)
+	return ok
+}
+
 // ============================================================================
 // Analytics Handlers
 // ============================================================================
@@ -145,39 +255,7 @@ func (s *FinanceService) GetSpendingTrends(ctx context.Context, req *connect.Req
 		periods = 6
 	}
 
-	now := time.Now()
-
-	// Pre-compute period boundaries for all periods (oldest first)
-	type periodInfo struct {
-		start time.Time
-		end   time.Time
-		label string
-	}
-	periodInfos := make([]periodInfo, periods)
-	for i := int32(0); i < periods; i++ {
-		offset := periods - 1 - i
-		var ps, pe time.Time
-		var label string
-		switch granularity {
-		case pfinancev1.Granularity_GRANULARITY_DAY:
-			ps = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()).AddDate(0, 0, -int(offset))
-			pe = ps.Add(24*time.Hour - time.Second)
-			label = ps.Format("2006-01-02")
-		case pfinancev1.Granularity_GRANULARITY_WEEK:
-			weekStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-			weekStart = weekStart.AddDate(0, 0, -int(weekStart.Weekday()))
-			ps = weekStart.AddDate(0, 0, -int(offset)*7)
-			pe = ps.AddDate(0, 0, 6)
-			pe = time.Date(pe.Year(), pe.Month(), pe.Day(), 23, 59, 59, 0, pe.Location())
-			label = ps.Format("Jan 02")
-		default:
-			ps = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location()).AddDate(0, -int(offset), 0)
-			pe = ps.AddDate(0, 1, -1)
-			pe = time.Date(pe.Year(), pe.Month(), pe.Day(), 23, 59, 59, 0, pe.Location())
-			label = ps.Format("Jan 2006")
-		}
-		periodInfos[i] = periodInfo{start: ps, end: pe, label: label}
-	}
+	periodInfos := buildTrendPeriods(time.Now(), granularity, periods)
 
 	// Single fetch for the entire date range (oldest start → newest end) instead of N+1 queries
 	overallStart := periodInfos[0].start
@@ -189,6 +267,43 @@ func (s *FinanceService) GetSpendingTrends(ctx context.Context, req *connect.Req
 	allIncomes, _, err := s.store.ListIncomes(ctx, userID, req.Msg.GroupId, &overallStart, &overallEnd, 10000, "")
 	if err != nil {
 		return nil, auth.WrapStoreError("list incomes", err)
+	}
+
+	hasCurrentWindowData := hasExpenseForCategory(allExpenses, req.Msg.Category) || len(allIncomes) > 0
+	if req.Msg.Category != pfinancev1.ExpenseCategory_EXPENSE_CATEGORY_UNSPECIFIED {
+		hasCurrentWindowData = hasExpenseForCategory(allExpenses, req.Msg.Category)
+	}
+	if !hasCurrentWindowData {
+		historicalExpenses, _, err := s.store.ListExpenses(ctx, userID, req.Msg.GroupId, nil, nil, 10000, "")
+		if err != nil {
+			return nil, auth.WrapStoreError("list historical expenses", err)
+		}
+		historicalIncomes, _, err := s.store.ListIncomes(ctx, userID, req.Msg.GroupId, nil, nil, 10000, "")
+		if err != nil {
+			return nil, auth.WrapStoreError("list historical incomes", err)
+		}
+
+		anchor, hasAnchor := latestExpenseDate(historicalExpenses, req.Msg.Category)
+		if req.Msg.Category == pfinancev1.ExpenseCategory_EXPENSE_CATEGORY_UNSPECIFIED {
+			if incomeAnchor, ok := latestIncomeDate(historicalIncomes); ok && (!hasAnchor || incomeAnchor.After(anchor)) {
+				anchor = incomeAnchor
+				hasAnchor = true
+			}
+		}
+
+		if hasAnchor {
+			periodInfos = buildTrendPeriods(anchor, granularity, periods)
+			overallStart = periodInfos[0].start
+			overallEnd = periodInfos[len(periodInfos)-1].end
+			allExpenses, _, err = s.store.ListExpenses(ctx, userID, req.Msg.GroupId, &overallStart, &overallEnd, 10000, "")
+			if err != nil {
+				return nil, auth.WrapStoreError("list anchored expenses", err)
+			}
+			allIncomes, _, err = s.store.ListIncomes(ctx, userID, req.Msg.GroupId, &overallStart, &overallEnd, 10000, "")
+			if err != nil {
+				return nil, auth.WrapStoreError("list anchored incomes", err)
+			}
+		}
 	}
 
 	// In-memory bucketing by period
@@ -287,35 +402,7 @@ func (s *FinanceService) GetCategoryComparison(ctx context.Context, req *connect
 		period = "month"
 	}
 
-	now := time.Now()
-	var currentStart, currentEnd, prevStart, prevEnd time.Time
-
-	switch period {
-	case "week":
-		daysFromSunday := int(now.Weekday())
-		currentStart = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()).AddDate(0, 0, -daysFromSunday)
-		currentEnd = currentStart.AddDate(0, 0, 6)
-		currentEnd = time.Date(currentEnd.Year(), currentEnd.Month(), currentEnd.Day(), 23, 59, 59, 0, currentEnd.Location())
-		prevStart = currentStart.AddDate(0, 0, -7)
-		prevEnd = currentStart.AddDate(0, 0, -1)
-		prevEnd = time.Date(prevEnd.Year(), prevEnd.Month(), prevEnd.Day(), 23, 59, 59, 0, prevEnd.Location())
-	case "quarter":
-		month := now.Month()
-		quarterStartMonth := time.Month(((int(month)-1)/3)*3 + 1)
-		currentStart = time.Date(now.Year(), quarterStartMonth, 1, 0, 0, 0, 0, now.Location())
-		currentEnd = currentStart.AddDate(0, 3, -1)
-		currentEnd = time.Date(currentEnd.Year(), currentEnd.Month(), currentEnd.Day(), 23, 59, 59, 0, currentEnd.Location())
-		prevStart = currentStart.AddDate(0, -3, 0)
-		prevEnd = currentStart.AddDate(0, 0, -1)
-		prevEnd = time.Date(prevEnd.Year(), prevEnd.Month(), prevEnd.Day(), 23, 59, 59, 0, prevEnd.Location())
-	default: // "month"
-		currentStart = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
-		currentEnd = currentStart.AddDate(0, 1, -1)
-		currentEnd = time.Date(currentEnd.Year(), currentEnd.Month(), currentEnd.Day(), 23, 59, 59, 0, currentEnd.Location())
-		prevStart = currentStart.AddDate(0, -1, 0)
-		prevEnd = currentStart.AddDate(0, 0, -1)
-		prevEnd = time.Date(prevEnd.Year(), prevEnd.Month(), prevEnd.Day(), 23, 59, 59, 0, prevEnd.Location())
-	}
+	currentStart, currentEnd, prevStart, prevEnd := categoryComparisonBounds(time.Now(), period)
 
 	// Fetch current period expenses
 	currentExpenses, _, err := s.store.ListExpenses(ctx, userID, req.Msg.GroupId, &currentStart, &currentEnd, 10000, "")
@@ -327,6 +414,24 @@ func (s *FinanceService) GetCategoryComparison(ctx context.Context, req *connect
 	prevExpenses, _, err := s.store.ListExpenses(ctx, userID, req.Msg.GroupId, &prevStart, &prevEnd, 10000, "")
 	if err != nil {
 		return nil, auth.WrapStoreError("list previous expenses", err)
+	}
+
+	if len(currentExpenses) == 0 && len(prevExpenses) == 0 {
+		historicalExpenses, _, err := s.store.ListExpenses(ctx, userID, req.Msg.GroupId, nil, nil, 10000, "")
+		if err != nil {
+			return nil, auth.WrapStoreError("list historical expenses", err)
+		}
+		if anchor, ok := latestExpenseDate(historicalExpenses, pfinancev1.ExpenseCategory_EXPENSE_CATEGORY_UNSPECIFIED); ok {
+			currentStart, currentEnd, prevStart, prevEnd = categoryComparisonBounds(anchor, period)
+			currentExpenses, _, err = s.store.ListExpenses(ctx, userID, req.Msg.GroupId, &currentStart, &currentEnd, 10000, "")
+			if err != nil {
+				return nil, auth.WrapStoreError("list anchored current expenses", err)
+			}
+			prevExpenses, _, err = s.store.ListExpenses(ctx, userID, req.Msg.GroupId, &prevStart, &prevEnd, 10000, "")
+			if err != nil {
+				return nil, auth.WrapStoreError("list anchored previous expenses", err)
+			}
+		}
 	}
 
 	// Group by category

--- a/backend/internal/service/analytics_service_test.go
+++ b/backend/internal/service/analytics_service_test.go
@@ -423,6 +423,102 @@ func TestAnalyticsGetCategoryComparison(t *testing.T) {
 	})
 }
 
+func TestAnalyticsCategoryViewsUseLatestExpenseWhenCurrentWindowEmpty(t *testing.T) {
+	mem := store.NewMemoryStore()
+	service := NewFinanceService(mem, nil, nil)
+
+	userID := "historical-user"
+	ctx := testProContext(userID)
+
+	now := time.Now()
+	latestMonth := time.Date(now.Year(), now.Month(), 15, 12, 0, 0, 0, time.UTC).AddDate(0, -4, 0)
+	previousMonth := latestMonth.AddDate(0, -1, 0)
+
+	expenses := []*pfinancev1.Expense{
+		{
+			Id:          "food-latest",
+			UserId:      userID,
+			Description: "Historical groceries",
+			Amount:      120,
+			AmountCents: 12000,
+			Category:    pfinancev1.ExpenseCategory_EXPENSE_CATEGORY_FOOD,
+			Date:        timestamppb.New(latestMonth),
+		},
+		{
+			Id:          "transport-latest",
+			UserId:      userID,
+			Description: "Historical train",
+			Amount:      45,
+			AmountCents: 4500,
+			Category:    pfinancev1.ExpenseCategory_EXPENSE_CATEGORY_TRANSPORTATION,
+			Date:        timestamppb.New(latestMonth.AddDate(0, 0, 2)),
+		},
+		{
+			Id:          "food-previous",
+			UserId:      userID,
+			Description: "Earlier groceries",
+			Amount:      80,
+			AmountCents: 8000,
+			Category:    pfinancev1.ExpenseCategory_EXPENSE_CATEGORY_FOOD,
+			Date:        timestamppb.New(previousMonth),
+		},
+	}
+
+	for _, expense := range expenses {
+		if err := mem.CreateExpense(ctx, expense); err != nil {
+			t.Fatalf("CreateExpense(%s): %v", expense.Id, err)
+		}
+	}
+
+	t.Run("category comparison anchors to the latest expense period", func(t *testing.T) {
+		resp, err := service.GetCategoryComparison(ctx, connect.NewRequest(&pfinancev1.GetCategoryComparisonRequest{
+			UserId:        userID,
+			CurrentPeriod: "month",
+		}))
+		if err != nil {
+			t.Fatalf("GetCategoryComparison: %v", err)
+		}
+
+		var food *pfinancev1.CategorySpending
+		for _, category := range resp.Msg.Categories {
+			if category.Category == pfinancev1.ExpenseCategory_EXPENSE_CATEGORY_FOOD {
+				food = category
+				break
+			}
+		}
+		if food == nil {
+			t.Fatalf("expected food category in historical comparison, got %v", resp.Msg.Categories)
+		}
+		if food.CurrentAmount != 120 {
+			t.Fatalf("current food amount = %.2f, want 120.00", food.CurrentAmount)
+		}
+		if food.PreviousAmount != 80 {
+			t.Fatalf("previous food amount = %.2f, want 80.00", food.PreviousAmount)
+		}
+	})
+
+	t.Run("category spending trends anchor to the latest matching category expense", func(t *testing.T) {
+		resp, err := service.GetSpendingTrends(ctx, connect.NewRequest(&pfinancev1.GetSpendingTrendsRequest{
+			UserId:      userID,
+			Granularity: pfinancev1.Granularity_GRANULARITY_MONTH,
+			Periods:     2,
+			Category:    pfinancev1.ExpenseCategory_EXPENSE_CATEGORY_FOOD,
+		}))
+		if err != nil {
+			t.Fatalf("GetSpendingTrends: %v", err)
+		}
+		if len(resp.Msg.ExpenseSeries) != 2 {
+			t.Fatalf("expense series length = %d, want 2", len(resp.Msg.ExpenseSeries))
+		}
+		if resp.Msg.ExpenseSeries[0].Value != 80 {
+			t.Fatalf("previous food trend value = %.2f, want 80.00", resp.Msg.ExpenseSeries[0].Value)
+		}
+		if resp.Msg.ExpenseSeries[1].Value != 120 {
+			t.Fatalf("latest food trend value = %.2f, want 120.00", resp.Msg.ExpenseSeries[1].Value)
+		}
+	})
+}
+
 // --------------------------------------------------------------------------
 // TestAnalyticsDetectAnomalies
 // --------------------------------------------------------------------------

--- a/web/e2e/analytics.spec.ts
+++ b/web/e2e/analytics.spec.ts
@@ -146,6 +146,9 @@ test.describe('Advanced Analytics', () => {
 
     await page.getByRole('tab', { name: 'Categories' }).click();
     await expect(page.getByText('Category Comparison')).toBeVisible();
+    await expect(page.getByRole('combobox', { name: 'Category comparison period' })).toBeVisible();
+    await expect(page.getByText('No category data available.')).toBeHidden();
+    await expect(page.getByText('Food').first()).toBeVisible();
 
     await page.getByRole('tab', { name: 'Anomalies' }).click();
     await expect(page.getByText('No anomalies detected. Your spending looks normal!')).toBeVisible();

--- a/web/src/app/(app)/personal/analytics/__tests__/AnalyticsPage.test.tsx
+++ b/web/src/app/(app)/personal/analytics/__tests__/AnalyticsPage.test.tsx
@@ -2,6 +2,19 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import AnalyticsPage from '../page';
 
+const mockUseCategoryComparison = jest.fn((_includeBudgets?: boolean, _period?: string) => ({
+  data: [
+    {
+      category: 'Food',
+      currentValue: 320,
+      previousValue: 240,
+      maxValue: 320,
+    },
+  ],
+  loading: false,
+  error: null,
+}));
+
 jest.mock('../../../../components/ProFeatureGate', () => ({
   ProFeatureGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   UpgradePrompt: ({ feature }: { feature: string }) => <div>{feature} requires Pro</div>,
@@ -34,11 +47,8 @@ jest.mock('../../../../metrics/hooks/useAnalyticsData', () => ({
     loading: false,
     error: null,
   }),
-  useCategoryComparison: () => ({
-    data: [],
-    loading: false,
-    error: null,
-  }),
+  useCategoryComparison: (includeBudgets: boolean, period: string) =>
+    mockUseCategoryComparison(includeBudgets, period),
   useAnomalies: () => ({
     data: [],
     totalAnomalousSpend: 0,
@@ -76,6 +86,10 @@ jest.mock('../../../../metrics/hooks/useExtractionMetrics', () => ({
 }));
 
 describe('AnalyticsPage', () => {
+  beforeEach(() => {
+    mockUseCategoryComparison.mockClear();
+  });
+
   it('includes a dedicated category spend over time view', async () => {
     const user = userEvent.setup();
     render(<AnalyticsPage />);
@@ -85,5 +99,15 @@ describe('AnalyticsPage', () => {
     expect(
       screen.getByRole('heading', { name: 'Category Spend Over Time' })
     ).toBeInTheDocument();
+  });
+
+  it('shows category analysis by default using a yearly comparison period', async () => {
+    const user = userEvent.setup();
+    render(<AnalyticsPage />);
+
+    await user.click(screen.getByRole('tab', { name: 'Categories' }));
+
+    expect(screen.getByTestId('radar-chart')).toBeInTheDocument();
+    expect(mockUseCategoryComparison).toHaveBeenCalledWith(true, 'year');
   });
 });

--- a/web/src/app/(app)/personal/analytics/page.tsx
+++ b/web/src/app/(app)/personal/analytics/page.tsx
@@ -24,6 +24,7 @@ import {
   useAnomalies,
   useCashFlowForecast,
   useWaterfallData,
+  type CategoryComparisonPeriod,
 } from '../../../metrics/hooks/useAnalyticsData';
 import { useExtractionMetrics } from '../../../metrics/hooks/useExtractionMetrics';
 import { UpgradePrompt } from '../../../components/ProFeatureGate';
@@ -266,7 +267,8 @@ function TrendsTab() {
 
 function CategoriesTab() {
   const [includeBudgets, setIncludeBudgets] = useState(true);
-  const { data, loading, error } = useCategoryComparison(includeBudgets);
+  const [period, setPeriod] = useState<CategoryComparisonPeriod>('year');
+  const { data, loading, error } = useCategoryComparison(includeBudgets, period);
 
   return (
     <Card>
@@ -275,12 +277,24 @@ function CategoriesTab() {
           <CardTitle>Category Comparison</CardTitle>
           <CardDescription>Compare spending across categories vs previous period</CardDescription>
         </div>
-        <button
-          onClick={() => setIncludeBudgets(!includeBudgets)}
-          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-        >
-          {includeBudgets ? 'Hide budgets' : 'Show budgets'}
-        </button>
+        <div className="flex items-center gap-2">
+          <Select value={period} onValueChange={(v) => setPeriod(v as CategoryComparisonPeriod)}>
+            <SelectTrigger className="w-28" aria-label="Category comparison period">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="month">Month</SelectItem>
+              <SelectItem value="quarter">Quarter</SelectItem>
+              <SelectItem value="year">Year</SelectItem>
+            </SelectContent>
+          </Select>
+          <button
+            onClick={() => setIncludeBudgets(!includeBudgets)}
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {includeBudgets ? 'Hide budgets' : 'Show budgets'}
+          </button>
+        </div>
       </CardHeader>
       <CardContent>
         {error && <ErrorBanner message={error} />}

--- a/web/src/app/metrics/hooks/__tests__/useAnalyticsData.test.ts
+++ b/web/src/app/metrics/hooks/__tests__/useAnalyticsData.test.ts
@@ -1,11 +1,12 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import { useHeatmapData } from '../useAnalyticsData';
+import { useCategoryComparison, useHeatmapData } from '../useAnalyticsData';
 import { ExpenseCategory } from '@/gen/pfinance/v1/types_pb';
 import { financeClient } from '@/lib/financeService';
 
 jest.mock('@/lib/financeService', () => ({
   financeClient: {
     getDailyAggregates: jest.fn(),
+    getCategoryComparison: jest.fn(),
   },
 }));
 
@@ -80,5 +81,28 @@ describe('useHeatmapData', () => {
       },
     ]);
     expect(result.current.data?.maxValue).toBe(42);
+  });
+});
+
+describe('useCategoryComparison', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requests the selected comparison period from the analytics API', async () => {
+    (financeClient.getCategoryComparison as jest.Mock).mockResolvedValue({
+      categories: [],
+    });
+
+    renderHook(() => useCategoryComparison(false, 'year'));
+
+    await waitFor(() =>
+      expect(financeClient.getCategoryComparison).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currentPeriod: 'year',
+          includeBudgets: false,
+        })
+      )
+    );
   });
 });

--- a/web/src/app/metrics/hooks/useAnalyticsData.ts
+++ b/web/src/app/metrics/hooks/useAnalyticsData.ts
@@ -338,7 +338,12 @@ export function useSpendingTrends(
 // Hook 3: useCategoryComparison
 // ============================================================================
 
-export function useCategoryComparison(includeBudgets: boolean) {
+export type CategoryComparisonPeriod = 'week' | 'month' | 'quarter' | 'year';
+
+export function useCategoryComparison(
+  includeBudgets: boolean,
+  currentPeriod: CategoryComparisonPeriod = 'month'
+) {
   const [data, setData] = useState<RadarAxis[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -350,7 +355,7 @@ export function useCategoryComparison(includeBudgets: boolean) {
       const response = await financeClient.getCategoryComparison({
         userId: '',
         groupId: '',
-        currentPeriod: 'month',
+        currentPeriod,
         includeBudgets,
       });
 
@@ -394,7 +399,7 @@ export function useCategoryComparison(includeBudgets: boolean) {
     } finally {
       setLoading(false);
     }
-  }, [includeBudgets]);
+  }, [includeBudgets, currentPeriod]);
 
   useEffect(() => {
     fetchData();


### PR DESCRIPTION
## Summary
- anchor spending trends and category comparison to the latest available expense when the current window is empty
- default the category analytics tab to a yearly comparison and expose month/quarter/year selection
- add backend, hook, page, and e2e coverage for populated category analytics

## Validation
- go test ./internal/service -run TestAnalytics -count=1
- npm test -- --runTestsByPath 'src/app/metrics/hooks/__tests__/useAnalyticsData.test.ts' 'src/app/(app)/personal/analytics/__tests__/AnalyticsPage.test.tsx' --runInBand
- npm run type-check
- NEXT_PUBLIC_DEV_MODE=true npx playwright test e2e/analytics.spec.ts --project=chromium
- direct Firestore/Auth inspection for ben.ebsworth@gmail.com confirmed 28 personal expenses dated 2025-12-05..2026-02-06 across 8 categories, and local patched analytics returned category rows