### PR TITLE
Add analytics time window controls

### DIFF
--- a/web/e2e/analytics.spec.ts
+++ b/web/e2e/analytics.spec.ts
@@ -142,11 +142,18 @@ test.describe('Advanced Analytics', () => {
     await page.getByRole('tab', { name: 'Trends' }).click();
     await expect(page.getByText('Spending Trends')).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Category Spend Over Time' })).toBeVisible();
+    await expect(page.getByRole('combobox', { name: 'Trend time window' })).toBeVisible();
     await expect(page.getByRole('combobox', { name: 'Category trend category' })).toBeVisible();
+    await page.getByRole('combobox', { name: 'Trend time window' }).click();
+    await page.getByRole('option', { name: '24 weeks' }).click();
+    await expect(page.getByRole('combobox', { name: 'Trend time window' })).toContainText('24 weeks');
 
     await page.getByRole('tab', { name: 'Categories' }).click();
     await expect(page.getByText('Category Comparison')).toBeVisible();
-    await expect(page.getByRole('combobox', { name: 'Category comparison period' })).toBeVisible();
+    await expect(page.getByRole('combobox', { name: 'Category comparison time window' })).toBeVisible();
+    await page.getByRole('combobox', { name: 'Category comparison time window' }).click();
+    await page.getByRole('option', { name: 'Quarter' }).click();
+    await expect(page.getByRole('combobox', { name: 'Category comparison time window' })).toContainText('Quarter');
     await expect(page.getByText('No category data available.')).toBeHidden();
     await expect(page.getByText('Food').first()).toBeVisible();
 

--- a/web/src/app/(app)/personal/analytics/__tests__/AnalyticsPage.test.tsx
+++ b/web/src/app/(app)/personal/analytics/__tests__/AnalyticsPage.test.tsx
@@ -2,6 +2,15 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import AnalyticsPage from '../page';
 
+const mockUseSpendingTrends = jest.fn((_granularity?: string, _periods?: number, _category?: string) => ({
+  expenseSeries: [{ date: '2026-05-01', value: 42, valueCents: BigInt(4200), label: 'May 1' }],
+  incomeSeries: [],
+  trendSlope: 0,
+  trendRSquared: 1,
+  loading: false,
+  error: null,
+}));
+
 const mockUseCategoryComparison = jest.fn((_includeBudgets?: boolean, _period?: string) => ({
   data: [
     {
@@ -39,14 +48,8 @@ jest.mock('../../../../metrics/hooks/useAnalyticsData', () => ({
     loading: false,
     error: null,
   }),
-  useSpendingTrends: () => ({
-    expenseSeries: [{ date: '2026-05-01', value: 42, valueCents: BigInt(4200), label: 'May 1' }],
-    incomeSeries: [],
-    trendSlope: 0,
-    trendRSquared: 1,
-    loading: false,
-    error: null,
-  }),
+  useSpendingTrends: (granularity: string, periods: number, category?: string) =>
+    mockUseSpendingTrends(granularity, periods, category),
   useCategoryComparison: (includeBudgets: boolean, period: string) =>
     mockUseCategoryComparison(includeBudgets, period),
   useAnomalies: () => ({
@@ -86,7 +89,27 @@ jest.mock('../../../../metrics/hooks/useExtractionMetrics', () => ({
 }));
 
 describe('AnalyticsPage', () => {
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'hasPointerCapture', {
+      configurable: true,
+      value: jest.fn(() => false),
+    });
+    Object.defineProperty(HTMLElement.prototype, 'setPointerCapture', {
+      configurable: true,
+      value: jest.fn(),
+    });
+    Object.defineProperty(HTMLElement.prototype, 'releasePointerCapture', {
+      configurable: true,
+      value: jest.fn(),
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: jest.fn(),
+    });
+  });
+
   beforeEach(() => {
+    mockUseSpendingTrends.mockClear();
     mockUseCategoryComparison.mockClear();
   });
 
@@ -101,6 +124,20 @@ describe('AnalyticsPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('lets users change the category trend time window', async () => {
+    const user = userEvent.setup();
+    render(<AnalyticsPage />);
+
+    await user.click(screen.getByRole('tab', { name: 'Trends' }));
+
+    expect(screen.getByText('Time window')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('combobox', { name: 'Trend time window' }));
+    await user.click(screen.getByRole('option', { name: '24 weeks' }));
+
+    expect(mockUseSpendingTrends).toHaveBeenCalledWith('week', 24, 'Food');
+  });
+
   it('shows category analysis by default using a yearly comparison period', async () => {
     const user = userEvent.setup();
     render(<AnalyticsPage />);
@@ -109,5 +146,19 @@ describe('AnalyticsPage', () => {
 
     expect(screen.getByTestId('radar-chart')).toBeInTheDocument();
     expect(mockUseCategoryComparison).toHaveBeenCalledWith(true, 'year');
+  });
+
+  it('lets users change the category comparison time window', async () => {
+    const user = userEvent.setup();
+    render(<AnalyticsPage />);
+
+    await user.click(screen.getByRole('tab', { name: 'Categories' }));
+
+    expect(screen.getByText('Time window')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('combobox', { name: 'Category comparison time window' }));
+    await user.click(screen.getByRole('option', { name: 'Quarter' }));
+
+    expect(mockUseCategoryComparison).toHaveBeenCalledWith(true, 'quarter');
   });
 });

--- a/web/src/app/(app)/personal/analytics/page.tsx
+++ b/web/src/app/(app)/personal/analytics/page.tsx
@@ -80,6 +80,14 @@ function toTrendChartData(
   }));
 }
 
+function trendWindowLabel(
+  granularity: 'day' | 'week' | 'month',
+  periods: number
+): string {
+  const unit = periods === 1 ? granularity : `${granularity}s`;
+  return `${periods} ${unit}`;
+}
+
 // ============================================================================
 // Tab: Heatmap
 // ============================================================================
@@ -148,6 +156,7 @@ function TrendsTab() {
   const [granularity, setGranularity] = useState<'day' | 'week' | 'month'>('week');
   const [periods, setPeriods] = useState(12);
   const [category, setCategory] = useState<ExpenseCategoryName>('Food');
+  const trendWindowOptions = [6, 12, 24];
 
   const { expenseSeries, incomeSeries, trendSlope, trendRSquared, loading, error } =
     useSpendingTrends(granularity, periods);
@@ -175,27 +184,35 @@ function TrendsTab() {
             <CardTitle>Spending Trends</CardTitle>
             <CardDescription>Track spending patterns over time</CardDescription>
           </div>
-          <div className="flex items-center gap-2">
-            <Select value={granularity} onValueChange={(v) => setGranularity(v as typeof granularity)}>
-              <SelectTrigger className="w-24" aria-label="Trend granularity">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="day">Daily</SelectItem>
-                <SelectItem value="week">Weekly</SelectItem>
-                <SelectItem value="month">Monthly</SelectItem>
-              </SelectContent>
-            </Select>
-            <Select value={String(periods)} onValueChange={(v) => setPeriods(Number(v))}>
-              <SelectTrigger className="w-24" aria-label="Trend period count">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="6">6 periods</SelectItem>
-                <SelectItem value="12">12 periods</SelectItem>
-                <SelectItem value="24">24 periods</SelectItem>
-              </SelectContent>
-            </Select>
+          <div className="flex flex-wrap items-end gap-2">
+            <div className="space-y-1">
+              <span className="block text-xs font-medium text-muted-foreground">Granularity</span>
+              <Select value={granularity} onValueChange={(v) => setGranularity(v as typeof granularity)}>
+                <SelectTrigger className="w-24" aria-label="Trend granularity">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="day">Daily</SelectItem>
+                  <SelectItem value="week">Weekly</SelectItem>
+                  <SelectItem value="month">Monthly</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <span className="block text-xs font-medium text-muted-foreground">Time window</span>
+              <Select value={String(periods)} onValueChange={(v) => setPeriods(Number(v))}>
+                <SelectTrigger className="w-28" aria-label="Trend time window">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {trendWindowOptions.map((option) => (
+                    <SelectItem key={option} value={String(option)}>
+                      {trendWindowLabel(granularity, option)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
           </div>
         </CardHeader>
         <CardContent>
@@ -277,17 +294,20 @@ function CategoriesTab() {
           <CardTitle>Category Comparison</CardTitle>
           <CardDescription>Compare spending across categories vs previous period</CardDescription>
         </div>
-        <div className="flex items-center gap-2">
-          <Select value={period} onValueChange={(v) => setPeriod(v as CategoryComparisonPeriod)}>
-            <SelectTrigger className="w-28" aria-label="Category comparison period">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="month">Month</SelectItem>
-              <SelectItem value="quarter">Quarter</SelectItem>
-              <SelectItem value="year">Year</SelectItem>
-            </SelectContent>
-          </Select>
+        <div className="flex flex-wrap items-end gap-2">
+          <div className="space-y-1">
+            <span className="block text-xs font-medium text-muted-foreground">Time window</span>
+            <Select value={period} onValueChange={(v) => setPeriod(v as CategoryComparisonPeriod)}>
+              <SelectTrigger className="w-28" aria-label="Category comparison time window">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="month">Month</SelectItem>
+                <SelectItem value="quarter">Quarter</SelectItem>
+                <SelectItem value="year">Year</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
           <button
             onClick={() => setIncludeBudgets(!includeBudgets)}
             className="text-sm text-muted-foreground hover:text-foreground transition-colors"


### PR DESCRIPTION
## Summary
- make analytics time-window controls visible in Trends and Categories
- label trend windows contextually, e.g. 24 weeks for weekly trend data
- update analytics unit and e2e coverage for changing these controls

## Tests
- npm test -- --runTestsByPath 'src/app/(app)/personal/analytics/__tests__/AnalyticsPage.test.tsx' --runInBand
- npm run type-check
- NEXT_PUBLIC_DEV_MODE=true npx playwright test e2e/analytics.spec.ts --project=chromium