### PR TITLE
Show stacked category spend trends

### DIFF
--- a/web/e2e/analytics.spec.ts
+++ b/web/e2e/analytics.spec.ts
@@ -71,6 +71,35 @@ test.describe('Advanced Analytics', () => {
       });
     });
 
+    await page.route('**/pfinance.v1.FinanceService/ListExpenses', async (route) => {
+      await fulfillConnect(route, {
+        expenses: [
+          {
+            id: 'food-1',
+            description: 'Groceries',
+            amount: 48,
+            category: 1,
+            date: '2026-04-20T10:00:00Z',
+          },
+          {
+            id: 'transport-1',
+            description: 'Train',
+            amount: 22,
+            category: 3,
+            date: '2026-04-27T10:00:00Z',
+          },
+          {
+            id: 'shopping-1',
+            description: 'Supplies',
+            amount: 35,
+            category: 7,
+            date: '2026-05-04T10:00:00Z',
+          },
+        ],
+        nextPageToken: '',
+      });
+    });
+
     await page.route('**/pfinance.v1.FinanceService/GetCategoryComparison', async (route) => {
       await fulfillConnect(route, {
         categories: [
@@ -143,7 +172,11 @@ test.describe('Advanced Analytics', () => {
     await expect(page.getByText('Spending Trends')).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Category Spend Over Time' })).toBeVisible();
     await expect(page.getByRole('combobox', { name: 'Trend time window' })).toBeVisible();
-    await expect(page.getByRole('combobox', { name: 'Category trend category' })).toBeVisible();
+    const trendsPanel = page.getByRole('tabpanel', { name: 'Trends' });
+    await expect(trendsPanel.getByText('No category trend data available.')).toBeHidden();
+    await expect(trendsPanel.getByText('Food').first()).toBeVisible();
+    await expect(trendsPanel.getByText('Transportation').first()).toBeVisible();
+    await expect(trendsPanel.getByText('Shopping').first()).toBeVisible();
     await page.getByRole('combobox', { name: 'Trend time window' }).click();
     await page.getByRole('option', { name: '24 weeks' }).click();
     await expect(page.getByRole('combobox', { name: 'Trend time window' })).toContainText('24 weeks');

--- a/web/src/app/(app)/personal/analytics/__tests__/AnalyticsPage.test.tsx
+++ b/web/src/app/(app)/personal/analytics/__tests__/AnalyticsPage.test.tsx
@@ -24,6 +24,23 @@ const mockUseCategoryComparison = jest.fn((_includeBudgets?: boolean, _period?: 
   error: null,
 }));
 
+const mockUseCategorySpendingTrends = jest.fn((_granularity?: string, _periods?: number) => ({
+  points: [
+    {
+      date: '2026-05-01',
+      label: 'May 1',
+      total: 72,
+      categories: {
+        Food: 42,
+        Transportation: 30,
+      },
+    },
+  ],
+  categories: ['Food', 'Transportation'],
+  loading: false,
+  error: null,
+}));
+
 jest.mock('../../../../components/ProFeatureGate', () => ({
   ProFeatureGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   UpgradePrompt: ({ feature }: { feature: string }) => <div>{feature} requires Pro</div>,
@@ -36,6 +53,7 @@ jest.mock('../../../../context/FinanceContext', () => ({
 jest.mock('../../../../components/charts', () => ({
   LazySpendingHeatmap: () => <div data-testid="heatmap-chart" />,
   LazySpendingTrendChart: () => <div data-testid="trend-chart" />,
+  LazyCategoryStackedTrendChart: () => <div data-testid="category-stacked-chart" />,
   LazyCategoryRadarChart: () => <div data-testid="radar-chart" />,
   LazyAnomalyScatterPlot: () => <div data-testid="anomaly-chart" />,
   LazyCashFlowForecast: () => <div data-testid="forecast-chart" />,
@@ -50,6 +68,8 @@ jest.mock('../../../../metrics/hooks/useAnalyticsData', () => ({
   }),
   useSpendingTrends: (granularity: string, periods: number, category?: string) =>
     mockUseSpendingTrends(granularity, periods, category),
+  useCategorySpendingTrends: (granularity: string, periods: number) =>
+    mockUseCategorySpendingTrends(granularity, periods),
   useCategoryComparison: (includeBudgets: boolean, period: string) =>
     mockUseCategoryComparison(includeBudgets, period),
   useAnomalies: () => ({
@@ -110,6 +130,7 @@ describe('AnalyticsPage', () => {
 
   beforeEach(() => {
     mockUseSpendingTrends.mockClear();
+    mockUseCategorySpendingTrends.mockClear();
     mockUseCategoryComparison.mockClear();
   });
 
@@ -122,6 +143,8 @@ describe('AnalyticsPage', () => {
     expect(
       screen.getByRole('heading', { name: 'Category Spend Over Time' })
     ).toBeInTheDocument();
+    expect(screen.getByTestId('category-stacked-chart')).toBeInTheDocument();
+    expect(mockUseCategorySpendingTrends).toHaveBeenCalledWith('week', 12);
   });
 
   it('lets users change the category trend time window', async () => {
@@ -135,7 +158,7 @@ describe('AnalyticsPage', () => {
     await user.click(screen.getByRole('combobox', { name: 'Trend time window' }));
     await user.click(screen.getByRole('option', { name: '24 weeks' }));
 
-    expect(mockUseSpendingTrends).toHaveBeenCalledWith('week', 24, 'Food');
+    expect(mockUseCategorySpendingTrends).toHaveBeenCalledWith('week', 24);
   });
 
   it('shows category analysis by default using a yearly comparison period', async () => {

--- a/web/src/app/(app)/personal/analytics/page.tsx
+++ b/web/src/app/(app)/personal/analytics/page.tsx
@@ -12,6 +12,7 @@ import { ProFeatureGate } from '../../../components/ProFeatureGate';
 import {
   LazySpendingHeatmap,
   LazySpendingTrendChart,
+  LazyCategoryStackedTrendChart,
   LazyCategoryRadarChart,
   LazyAnomalyScatterPlot,
   LazyCashFlowForecast,
@@ -20,6 +21,7 @@ import {
 import {
   useHeatmapData,
   useSpendingTrends,
+  useCategorySpendingTrends,
   useCategoryComparison,
   useAnomalies,
   useCashFlowForecast,
@@ -30,21 +32,6 @@ import { useExtractionMetrics } from '../../../metrics/hooks/useExtractionMetric
 import { UpgradePrompt } from '../../../components/ProFeatureGate';
 import { AlertCircle, FileSearch } from 'lucide-react';
 import { useFinance } from '../../../context/FinanceContext';
-
-const expenseCategories = [
-  'Food',
-  'Housing',
-  'Transportation',
-  'Entertainment',
-  'Healthcare',
-  'Utilities',
-  'Shopping',
-  'Education',
-  'Travel',
-  'Other',
-] as const;
-
-type ExpenseCategoryName = (typeof expenseCategories)[number];
 
 function isSubscriptionError(message: string): boolean {
   const lower = message.toLowerCase();
@@ -155,27 +142,20 @@ function HeatmapTab() {
 function TrendsTab() {
   const [granularity, setGranularity] = useState<'day' | 'week' | 'month'>('week');
   const [periods, setPeriods] = useState(12);
-  const [category, setCategory] = useState<ExpenseCategoryName>('Food');
   const trendWindowOptions = [6, 12, 24];
 
   const { expenseSeries, incomeSeries, trendSlope, trendRSquared, loading, error } =
     useSpendingTrends(granularity, periods);
   const {
-    expenseSeries: categoryExpenseSeries,
-    trendSlope: categoryTrendSlope,
-    trendRSquared: categoryTrendRSquared,
-    loading: categoryLoading,
-    error: categoryError,
-  } = useSpendingTrends(granularity, periods, category);
+    points: categoryTrendPoints,
+    categories: categoryTrendCategories,
+    loading: categoryTrendLoading,
+    error: categoryTrendError,
+  } = useCategorySpendingTrends(granularity, periods);
 
   const chartData = useMemo(() => toTrendChartData(expenseSeries), [expenseSeries]);
 
   const incomeData = useMemo(() => toTrendChartData(incomeSeries), [incomeSeries]);
-  const categoryChartData = useMemo(
-    () => toTrendChartData(categoryExpenseSeries),
-    [categoryExpenseSeries]
-  );
-
   return (
     <div className="space-y-4">
       <Card>
@@ -240,34 +220,21 @@ function TrendsTab() {
         <CardHeader className="flex flex-row items-center justify-between space-y-0">
           <div>
             <CardTitle role="heading" aria-level={3}>Category Spend Over Time</CardTitle>
-            <CardDescription>Isolate one category across the same period range</CardDescription>
+            <CardDescription>Stack every category across the selected time window</CardDescription>
           </div>
-          <Select value={category} onValueChange={(v) => setCategory(v as ExpenseCategoryName)}>
-            <SelectTrigger className="w-40" aria-label="Category trend category">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {expenseCategories.map((cat) => (
-                <SelectItem key={cat} value={cat}>
-                  {cat}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
         </CardHeader>
         <CardContent>
-          {categoryError && <ErrorBanner message={categoryError} />}
-          {categoryLoading && <LoadingSkeleton />}
-          {!categoryLoading && !categoryError && categoryChartData.length > 0 && (
+          {categoryTrendError && <ErrorBanner message={categoryTrendError} />}
+          {categoryTrendLoading && <LoadingSkeleton />}
+          {!categoryTrendLoading && !categoryTrendError && categoryTrendPoints.length > 0 && categoryTrendCategories.length > 0 && (
             <div className="h-[320px]">
-              <LazySpendingTrendChart
-                expenseSeries={categoryChartData}
-                trendSlope={categoryTrendSlope}
-                trendRSquared={categoryTrendRSquared}
+              <LazyCategoryStackedTrendChart
+                points={categoryTrendPoints}
+                categories={categoryTrendCategories}
               />
             </div>
           )}
-          {!categoryLoading && !categoryError && categoryChartData.length === 0 && (
+          {!categoryTrendLoading && !categoryTrendError && (categoryTrendPoints.length === 0 || categoryTrendCategories.length === 0) && (
             <div className="h-[320px] flex items-center justify-center text-muted-foreground text-sm">
               No category trend data available.
             </div>

--- a/web/src/app/components/charts/CategoryStackedTrendChart.tsx
+++ b/web/src/app/components/charts/CategoryStackedTrendChart.tsx
@@ -1,0 +1,327 @@
+'use client';
+
+import React, { useCallback, useMemo } from 'react';
+import { AreaStack, Bar, Line } from '@visx/shape';
+import { curveMonotoneX } from '@visx/curve';
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import { GridRows } from '@visx/grid';
+import { Group } from '@visx/group';
+import { scaleLinear, scaleTime } from '@visx/scale';
+import { localPoint } from '@visx/event';
+import { ParentSize } from '@visx/responsive';
+import { TooltipWithBounds, defaultStyles, useTooltip } from '@visx/tooltip';
+import { bisector } from 'd3-array';
+import type { CategoryStackedTrendPoint } from '@/app/metrics/types';
+
+interface CategoryStackedTrendChartProps {
+  points: CategoryStackedTrendPoint[];
+  categories: string[];
+}
+
+interface ChartPoint extends CategoryStackedTrendPoint {
+  dateValue: Date;
+}
+
+interface TooltipData {
+  point: ChartPoint;
+}
+
+const categoryColors: Record<string, string> = {
+  Food: 'var(--chart-1)',
+  Housing: 'var(--chart-2)',
+  Transportation: 'var(--chart-3)',
+  Entertainment: 'var(--chart-4)',
+  Healthcare: 'var(--chart-5)',
+  Utilities: '#2563eb',
+  Shopping: '#db2777',
+  Education: '#7c3aed',
+  Travel: '#0891b2',
+  Other: '#6b7280',
+};
+
+const fallbackColors = [
+  'var(--chart-1)',
+  'var(--chart-2)',
+  'var(--chart-3)',
+  'var(--chart-4)',
+  'var(--chart-5)',
+];
+
+const tooltipStyles: React.CSSProperties = {
+  ...defaultStyles,
+  backgroundColor: 'var(--popover)',
+  color: 'var(--popover-foreground)',
+  border: '1px solid var(--border)',
+  borderRadius: '6px',
+  fontSize: '12px',
+  padding: '8px 12px',
+  boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+};
+
+const bisectDate = bisector<ChartPoint, Date>((d) => d.dateValue).left;
+
+function parseLocalDate(date: string): Date {
+  return new Date(`${date}T00:00:00`);
+}
+
+function formatAmount(value: number): string {
+  return `$${value.toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function formatDateLabel(date: Date): string {
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function colorForCategory(category: string, index: number): string {
+  return categoryColors[category] ?? fallbackColors[index % fallbackColors.length];
+}
+
+function InnerCategoryStackedTrendChart({
+  points,
+  categories,
+  width,
+  height,
+}: CategoryStackedTrendChartProps & { width: number; height: number }) {
+  const {
+    tooltipData,
+    tooltipLeft,
+    tooltipTop,
+    tooltipOpen,
+    showTooltip,
+    hideTooltip,
+  } = useTooltip<TooltipData>();
+
+  const legendHeight = 58;
+  const svgHeight = Math.max(height - legendHeight, 240);
+  const margin = { top: 16, right: 16, bottom: 38, left: 60 };
+  const innerWidth = Math.max(width - margin.left - margin.right, 0);
+  const innerHeight = Math.max(svgHeight - margin.top - margin.bottom, 0);
+
+  const parsedPoints = useMemo(
+    () =>
+      points
+        .map((point) => ({
+          ...point,
+          dateValue: parseLocalDate(point.date),
+        }))
+        .sort((a, b) => a.dateValue.getTime() - b.dateValue.getTime()),
+    [points]
+  );
+
+  const [minDate, maxDate] = useMemo(() => {
+    const first = parsedPoints[0]?.dateValue ?? new Date();
+    const last = parsedPoints[parsedPoints.length - 1]?.dateValue ?? first;
+    if (first.getTime() !== last.getTime()) {
+      return [first, last];
+    }
+    const next = new Date(first);
+    next.setDate(next.getDate() + 1);
+    return [first, next];
+  }, [parsedPoints]);
+
+  const yMax = useMemo(
+    () => Math.max(...parsedPoints.map((point) => point.total), 0) * 1.1 || 1,
+    [parsedPoints]
+  );
+
+  const xScale = useMemo(
+    () =>
+      scaleTime<number>({
+        domain: [minDate, maxDate],
+        range: [0, innerWidth],
+      }),
+    [innerWidth, maxDate, minDate]
+  );
+
+  const yScale = useMemo(
+    () =>
+      scaleLinear<number>({
+        domain: [0, yMax],
+        range: [innerHeight, 0],
+        nice: true,
+      }),
+    [innerHeight, yMax]
+  );
+
+  const handleTooltip = useCallback(
+    (event: React.TouchEvent<SVGRectElement> | React.MouseEvent<SVGRectElement>) => {
+      const point = localPoint(event) || { x: 0 };
+      const x0 = xScale.invert(point.x - margin.left);
+      const index = bisectDate(parsedPoints, x0, 1);
+      const d0 = parsedPoints[index - 1];
+      const d1 = parsedPoints[index];
+      let nearest = d0;
+      if (d1 && d0) {
+        nearest =
+          x0.getTime() - d0.dateValue.getTime() >
+          d1.dateValue.getTime() - x0.getTime()
+            ? d1
+            : d0;
+      }
+      if (!nearest) return;
+
+      showTooltip({
+        tooltipData: { point: nearest },
+        tooltipLeft: xScale(nearest.dateValue) + margin.left,
+        tooltipTop: yScale(nearest.total) + margin.top,
+      });
+    },
+    [parsedPoints, showTooltip, xScale, yScale]
+  );
+
+  if (points.length === 0 || categories.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        No category trend data available.
+      </div>
+    );
+  }
+
+  const tooltipRows = tooltipData
+    ? categories
+        .map((category, index) => ({
+          category,
+          amount: tooltipData.point.categories[category] ?? 0,
+          color: colorForCategory(category, index),
+        }))
+        .filter((row) => row.amount > 0)
+        .sort((a, b) => b.amount - a.amount)
+    : [];
+
+  return (
+    <div style={{ position: 'relative', height }}>
+      <svg width={width} height={svgHeight} aria-label="Stacked category spend over time">
+        <Group left={margin.left} top={margin.top}>
+          <GridRows
+            scale={yScale}
+            width={innerWidth}
+            stroke="var(--border)"
+            strokeOpacity={0.5}
+            strokeDasharray="3,3"
+            numTicks={5}
+          />
+
+          <AreaStack<ChartPoint, string>
+            data={parsedPoints}
+            keys={categories}
+            value={(d, key) => d.categories[key] ?? 0}
+            x={(d) => xScale(d.data.dateValue) ?? 0}
+            y0={(d) => yScale(d[0]) ?? 0}
+            y1={(d) => yScale(d[1]) ?? 0}
+            curve={curveMonotoneX}
+            color={(key, index) => colorForCategory(String(key), index)}
+            fillOpacity={0.78}
+            stroke="var(--background)"
+            strokeWidth={1}
+          />
+
+          <AxisBottom
+            top={innerHeight}
+            scale={xScale}
+            numTicks={Math.min(6, points.length)}
+            tickFormat={(d) => formatDateLabel(d as Date)}
+            stroke="var(--border)"
+            tickStroke="var(--border)"
+            tickLabelProps={() => ({
+              fill: 'var(--muted-foreground)',
+              fontSize: 10,
+              textAnchor: 'middle' as const,
+            })}
+          />
+          <AxisLeft
+            scale={yScale}
+            numTicks={5}
+            tickFormat={(d) => `$${(d as number).toLocaleString()}`}
+            stroke="var(--border)"
+            tickStroke="var(--border)"
+            tickLabelProps={() => ({
+              fill: 'var(--muted-foreground)',
+              fontSize: 10,
+              textAnchor: 'end' as const,
+              dx: '-0.25em',
+              dy: '0.25em',
+            })}
+          />
+
+          <Bar
+            x={0}
+            y={0}
+            width={innerWidth}
+            height={innerHeight}
+            fill="transparent"
+            onTouchStart={handleTooltip}
+            onTouchMove={handleTooltip}
+            onMouseMove={handleTooltip}
+            onMouseLeave={hideTooltip}
+          />
+
+          {tooltipOpen && tooltipData && (
+            <Line
+              from={{ x: (tooltipLeft ?? 0) - margin.left, y: 0 }}
+              to={{ x: (tooltipLeft ?? 0) - margin.left, y: innerHeight }}
+              stroke="var(--muted-foreground)"
+              strokeWidth={1}
+              strokeDasharray="3,3"
+              pointerEvents="none"
+            />
+          )}
+        </Group>
+      </svg>
+
+      <div className="flex flex-wrap gap-x-4 gap-y-2 px-2 text-xs text-muted-foreground">
+        {categories.map((category, index) => (
+          <div key={category} className="flex items-center gap-1.5">
+            <span
+              className="h-2.5 w-2.5 rounded-sm"
+              style={{ backgroundColor: colorForCategory(category, index) }}
+            />
+            <span>{category}</span>
+          </div>
+        ))}
+      </div>
+
+      {tooltipOpen && tooltipData && (
+        <TooltipWithBounds left={tooltipLeft} top={tooltipTop} style={tooltipStyles}>
+          <div style={{ fontWeight: 600, marginBottom: 4 }}>
+            {tooltipData.point.label}
+          </div>
+          <div style={{ marginBottom: 6 }}>
+            Total: {formatAmount(tooltipData.point.total)}
+          </div>
+          {tooltipRows.map((row) => (
+            <div
+              key={row.category}
+              style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2 }}
+            >
+              <span
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: 2,
+                  backgroundColor: row.color,
+                  display: 'inline-block',
+                }}
+              />
+              {row.category}: {formatAmount(row.amount)}
+            </div>
+          ))}
+        </TooltipWithBounds>
+      )}
+    </div>
+  );
+}
+
+export default function CategoryStackedTrendChart(props: CategoryStackedTrendChartProps) {
+  return (
+    <ParentSize>
+      {({ width, height }) => {
+        if (width < 10) return null;
+        const chartHeight = Math.max(height, 300);
+        return <InnerCategoryStackedTrendChart {...props} width={width} height={chartHeight} />;
+      }}
+    </ParentSize>
+  );
+}

--- a/web/src/app/components/charts/LazyCategoryStackedTrendChart.tsx
+++ b/web/src/app/components/charts/LazyCategoryStackedTrendChart.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { ComponentProps } from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const CategoryStackedTrendChart = dynamic(
+  () => import('./CategoryStackedTrendChart'),
+  {
+    loading: () => (
+      <div className="flex h-64 w-full items-center justify-center">
+        <Skeleton className="h-full w-full rounded-lg" />
+      </div>
+    ),
+    ssr: false,
+  }
+);
+
+export type LazyCategoryStackedTrendChartProps = ComponentProps<typeof CategoryStackedTrendChart>;
+
+export default function LazyCategoryStackedTrendChart(props: LazyCategoryStackedTrendChartProps) {
+  return <CategoryStackedTrendChart {...props} />;
+}

--- a/web/src/app/components/charts/index.ts
+++ b/web/src/app/components/charts/index.ts
@@ -3,6 +3,7 @@ export { default as LazyExpenseSankey } from './LazyExpenseSankey';
 export { default as LazySalaryBreakdownChart } from './LazySalaryBreakdownChart';
 export { default as LazySpendingHeatmap } from './LazySpendingHeatmap';
 export { default as LazySpendingTrendChart } from './LazySpendingTrendChart';
+export { default as LazyCategoryStackedTrendChart } from './LazyCategoryStackedTrendChart';
 export { default as LazyCategoryRadarChart } from './LazyCategoryRadarChart';
 export { default as LazyAnomalyScatterPlot } from './LazyAnomalyScatterPlot';
 export { default as LazyCashFlowForecast } from './LazyCashFlowForecast';

--- a/web/src/app/metrics/hooks/__tests__/useAnalyticsData.test.ts
+++ b/web/src/app/metrics/hooks/__tests__/useAnalyticsData.test.ts
@@ -1,5 +1,9 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import { useCategoryComparison, useHeatmapData } from '../useAnalyticsData';
+import {
+  useCategoryComparison,
+  useCategorySpendingTrends,
+  useHeatmapData,
+} from '../useAnalyticsData';
 import { ExpenseCategory } from '@/gen/pfinance/v1/types_pb';
 import { financeClient } from '@/lib/financeService';
 
@@ -7,6 +11,7 @@ jest.mock('@/lib/financeService', () => ({
   financeClient: {
     getDailyAggregates: jest.fn(),
     getCategoryComparison: jest.fn(),
+    listExpenses: jest.fn(),
   },
 }));
 
@@ -104,5 +109,78 @@ describe('useCategoryComparison', () => {
         })
       )
     );
+  });
+});
+
+describe('useCategorySpendingTrends', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-05T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('buckets all category spend into one aligned stacked time series', async () => {
+    (financeClient.listExpenses as jest.Mock).mockResolvedValue({
+      expenses: [
+        {
+          id: 'food-1',
+          amount: 24,
+          amountCents: BigInt(2400),
+          category: ExpenseCategory.FOOD,
+          date: { seconds: BigInt(Math.floor(new Date('2026-05-04T10:00:00.000Z').getTime() / 1000)), nanos: 0 },
+        },
+        {
+          id: 'transport-1',
+          amount: 15,
+          amountCents: BigInt(1500),
+          category: ExpenseCategory.TRANSPORTATION,
+          date: { seconds: BigInt(Math.floor(new Date('2026-05-04T14:00:00.000Z').getTime() / 1000)), nanos: 0 },
+        },
+        {
+          id: 'food-2',
+          amount: 10,
+          amountCents: BigInt(1000),
+          category: ExpenseCategory.FOOD,
+          date: { seconds: BigInt(Math.floor(new Date('2026-04-28T09:00:00.000Z').getTime() / 1000)), nanos: 0 },
+        },
+      ],
+      nextPageToken: '',
+    });
+
+    const { result } = renderHook(() => useCategorySpendingTrends('week', 2));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(financeClient.listExpenses).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: '',
+        groupId: '',
+        pageSize: 10000,
+      })
+    );
+    expect(result.current.categories).toEqual(['Food', 'Transportation']);
+    expect(result.current.points).toEqual([
+      {
+        date: '2026-04-26',
+        label: 'Apr 26',
+        total: 10,
+        categories: {
+          Food: 10,
+          Transportation: 0,
+        },
+      },
+      {
+        date: '2026-05-03',
+        label: 'May 03',
+        total: 39,
+        categories: {
+          Food: 24,
+          Transportation: 15,
+        },
+      },
+    ]);
   });
 });

--- a/web/src/app/metrics/hooks/useAnalyticsData.ts
+++ b/web/src/app/metrics/hooks/useAnalyticsData.ts
@@ -7,6 +7,7 @@ import { TimestampSchema } from '@bufbuild/protobuf/wkt';
 import { financeClient } from '@/lib/financeService';
 import type {
   DailyAggregate,
+  Expense,
   TimeSeriesDataPoint,
   CategorySpending,
   SpendingAnomaly,
@@ -23,6 +24,7 @@ import {
 import type {
   HeatmapDay,
   HeatmapData,
+  CategoryStackedTrendPoint,
   RadarAxis,
   AnomalyPoint,
   ForecastSeries,
@@ -54,6 +56,10 @@ function startOfLocalDay(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }
 
+function endOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999);
+}
+
 function dateKeysInRange(startDate: Date, endDate: Date): string[] {
   const start = startOfLocalDay(startDate);
   const end = startOfLocalDay(endDate);
@@ -65,6 +71,56 @@ function dateKeysInRange(startDate: Date, endDate: Date): string[] {
     keys.push(localDateKey(cursor));
   }
   return keys;
+}
+
+interface TrendPeriod {
+  start: Date;
+  end: Date;
+  label: string;
+}
+
+function formatShortDate(date: Date): string {
+  return date.toLocaleDateString('en-US', { month: 'short', day: '2-digit' });
+}
+
+function buildTrendPeriods(
+  anchor: Date,
+  granularity: 'day' | 'week' | 'month',
+  periods: number
+): TrendPeriod[] {
+  return Array.from({ length: periods }, (_, index) => {
+    const offset = periods - 1 - index;
+
+    if (granularity === 'day') {
+      const start = startOfLocalDay(anchor);
+      start.setDate(start.getDate() - offset);
+      return {
+        start,
+        end: endOfLocalDay(start),
+        label: localDateKey(start),
+      };
+    }
+
+    if (granularity === 'week') {
+      const start = startOfLocalDay(anchor);
+      start.setDate(start.getDate() - start.getDay() - offset * 7);
+      const end = endOfLocalDay(start);
+      end.setDate(end.getDate() + 6);
+      return {
+        start,
+        end,
+        label: formatShortDate(start),
+      };
+    }
+
+    const start = new Date(anchor.getFullYear(), anchor.getMonth() - offset, 1);
+    const end = new Date(start.getFullYear(), start.getMonth() + 1, 0, 23, 59, 59, 999);
+    return {
+      start,
+      end,
+      label: start.toLocaleDateString('en-US', { month: 'short', year: 'numeric' }),
+    };
+  });
 }
 
 /**
@@ -114,6 +170,19 @@ function categoryFromString(cat: string): ExpenseCategory {
   };
   return mapping[upper] ?? ExpenseCategory.UNSPECIFIED;
 }
+
+const categoryOrder: ExpenseCategory[] = [
+  ExpenseCategory.FOOD,
+  ExpenseCategory.HOUSING,
+  ExpenseCategory.TRANSPORTATION,
+  ExpenseCategory.ENTERTAINMENT,
+  ExpenseCategory.HEALTHCARE,
+  ExpenseCategory.UTILITIES,
+  ExpenseCategory.SHOPPING,
+  ExpenseCategory.EDUCATION,
+  ExpenseCategory.TRAVEL,
+  ExpenseCategory.OTHER,
+];
 
 /**
  * Prefer cents value (converted to dollars) over the legacy double field.
@@ -335,7 +404,141 @@ export function useSpendingTrends(
 }
 
 // ============================================================================
-// Hook 3: useCategoryComparison
+// Hook 3: useCategorySpendingTrends
+// ============================================================================
+
+export interface CategorySpendingTrendsData {
+  points: CategoryStackedTrendPoint[];
+  categories: string[];
+}
+
+function expenseDate(expense: Expense): Date | null {
+  if (!expense.date) return null;
+  return new Date(Number(expense.date.seconds) * 1000 + Math.floor(expense.date.nanos / 1_000_000));
+}
+
+function findExpensePeriodIndex(date: Date, periods: TrendPeriod[]): number {
+  return periods.findIndex((period) => date >= period.start && date <= period.end);
+}
+
+function latestExpenseDate(expenses: Expense[]): Date | null {
+  let latest: Date | null = null;
+  for (const expense of expenses) {
+    const date = expenseDate(expense);
+    if (date && (!latest || date > latest)) {
+      latest = date;
+    }
+  }
+  return latest;
+}
+
+async function listAllExpenses(): Promise<Expense[]> {
+  const expenses: Expense[] = [];
+  let pageToken = '';
+
+  do {
+    const response = await financeClient.listExpenses({
+      userId: '',
+      groupId: '',
+      pageSize: 10000,
+      pageToken,
+    });
+    expenses.push(...response.expenses);
+    pageToken = response.nextPageToken;
+  } while (pageToken);
+
+  return expenses;
+}
+
+export function useCategorySpendingTrends(
+  granularity: 'day' | 'week' | 'month',
+  periods: number
+) {
+  const [data, setData] = useState<CategorySpendingTrendsData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const expenses = await listAllExpenses();
+      const currentPeriods = buildTrendPeriods(new Date(), granularity, periods);
+      const hasCurrentWindowData = expenses.some((expense) => {
+        const date = expenseDate(expense);
+        return date ? findExpensePeriodIndex(date, currentPeriods) !== -1 : false;
+      });
+      const anchor = hasCurrentWindowData ? new Date() : latestExpenseDate(expenses) ?? new Date();
+      const trendPeriods = buildTrendPeriods(anchor, granularity, periods);
+
+      const totalsByCategory = new Map<string, number>();
+      const points = trendPeriods.map((period) => ({
+        date: localDateKey(period.start),
+        label: period.label,
+        total: 0,
+        categories: {} as Record<string, number>,
+      }));
+
+      for (const category of categoryOrder) {
+        const label = categoryToString(category);
+        for (const point of points) {
+          point.categories[label] = 0;
+        }
+      }
+
+      for (const expense of expenses) {
+        const date = expenseDate(expense);
+        if (!date) continue;
+        const periodIndex = findExpensePeriodIndex(date, trendPeriods);
+        if (periodIndex === -1) continue;
+
+        const category = categoryToString(expense.category);
+        const amount = centsOrFallback(expense.amountCents, expense.amount);
+        points[periodIndex].categories[category] =
+          (points[periodIndex].categories[category] ?? 0) + amount;
+        points[periodIndex].total += amount;
+        totalsByCategory.set(category, (totalsByCategory.get(category) ?? 0) + amount);
+      }
+
+      const activeCategories = categoryOrder
+        .map(categoryToString)
+        .filter((category) => (totalsByCategory.get(category) ?? 0) > 0);
+
+      setData({
+        categories: activeCategories,
+        points: points.map((point) => ({
+          ...point,
+          categories: Object.fromEntries(
+            activeCategories.map((category) => [category, point.categories[category] ?? 0])
+          ),
+        })),
+      });
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Failed to fetch category spending trends'
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [granularity, periods]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return {
+    points: data?.points ?? [],
+    categories: data?.categories ?? [],
+    loading,
+    error,
+    refetch: fetchData,
+  };
+}
+
+// ============================================================================
+// Hook 4: useCategoryComparison
 // ============================================================================
 
 export type CategoryComparisonPeriod = 'week' | 'month' | 'quarter' | 'year';

--- a/web/src/app/metrics/types.ts
+++ b/web/src/app/metrics/types.ts
@@ -478,6 +478,16 @@ export interface RadarAxis {
 }
 
 /**
+ * One point in a stacked category spending trend.
+ */
+export interface CategoryStackedTrendPoint {
+  date: string;
+  label: string;
+  total: number;
+  categories: Record<string, number>;
+}
+
+/**
  * Anomaly point for scatter plot visualization
  */
 export interface AnomalyPoint {


### PR DESCRIPTION
## Summary
- add stacked category spend-over-time analytics using all available expense categories
- support day, week, and month windows in the category trend data hook
- update analytics tests and e2e coverage for the stacked category chart

## Test Plan
- npm test -- --runTestsByPath src/app/metrics/hooks/__tests__/useAnalyticsData.test.ts src/app/(app)/personal/analytics/__tests__/AnalyticsPage.test.tsx --runInBand
- npm run type-check
- NEXT_PUBLIC_DEV_MODE=true npx playwright test e2e/analytics.spec.ts --project=chromium